### PR TITLE
Add Audience support.

### DIFF
--- a/api/logout.go
+++ b/api/logout.go
@@ -9,7 +9,12 @@ import (
 func (a *API) Logout(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	token := getToken(ctx)
 
-	a.db.Logout(token.Claims["id"])
+	id, ok := token.Claims["id"].(string)
+	if !ok {
+		BadRequestError(w, "Could not read User ID claim")
+		return
+	}
 
+	a.db.Logout(id)
 	w.WriteHeader(204)
 }

--- a/api/recover.go
+++ b/api/recover.go
@@ -29,7 +29,8 @@ func (a *API) Recover(ctx context.Context, w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	user, err := a.db.FindUserByEmail(params.Email)
+	aud := a.requestAud(r)
+	user, err := a.db.FindUserByEmailAndAudience(params.Email, aud)
 	if err != nil {
 		if models.IsNotFoundError(err) {
 			NotFoundError(w, err.Error())

--- a/api/signup.go
+++ b/api/signup.go
@@ -33,14 +33,16 @@ func (a *API) Signup(ctx context.Context, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	user, err := a.db.FindUserByEmail(params.Email)
+	aud := a.requestAud(r)
+
+	user, err := a.db.FindUserByEmailAndAudience(params.Email, aud)
 	if err != nil {
 		if !models.IsNotFoundError(err) {
 			InternalServerError(w, err.Error())
 			return
 		}
 
-		user, err = a.signupNewUser(params)
+		user, err = a.signupNewUser(params, aud)
 		if err != nil {
 			InternalServerError(w, err.Error())
 			return
@@ -61,8 +63,8 @@ func (a *API) Signup(ctx context.Context, w http.ResponseWriter, r *http.Request
 	sendJSON(w, 200, user)
 }
 
-func (a *API) signupNewUser(params *SignupParams) (*models.User, error) {
-	user, err := models.NewUser(params.Email, params.Password, params.Data)
+func (a *API) signupNewUser(params *SignupParams, aud string) (*models.User, error) {
+	user, err := models.NewUser(params.Email, params.Password, aud, params.Data)
 	if err != nil {
 		return nil, err
 	}

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -26,6 +26,7 @@ type DBConfiguration struct {
 type JWTConfiguration struct {
 	Secret             string `json:"secret"`
 	Exp                int    `json:"exp"`
+	Aud                string `json:"aud"`
 	AdminGroupName     string `json:"admin_group_name"`
 	AdminGroupDisabled bool   `json:"admin_group_disabled"`
 }

--- a/config.example.json
+++ b/config.example.json
@@ -1,7 +1,8 @@
 {
   "jwt": {
     "secret": "CHANGE-THIS! VERY IMPORTANT!",
-    "exp": 3600
+    "exp": 3600,
+    "aud": "api.netlify.com"
   },
   "db": {
     "driver": "sqlite3",

--- a/models/user.go
+++ b/models/user.go
@@ -14,6 +14,7 @@ import (
 type User struct {
 	ID string `json:"id" bson:"_id,omitempty"`
 
+	Aud               string    `json:"aud" bson:"aud"`
 	Email             string    `json:"email" bson:"email"`
 	EncryptedPassword string    `json:"-" bson:"encrypted_password"`
 	ConfirmedAt       time.Time `json:"confirmed_at" bson:"confirmed_at"`
@@ -38,9 +39,10 @@ type User struct {
 }
 
 // NewUser initializes a new user from an email, password and user data.
-func NewUser(email, password string, userData map[string]interface{}) (*User, error) {
+func NewUser(email, password, aud string, userData map[string]interface{}) (*User, error) {
 	user := &User{
 		ID:           uuid.NewRandom().String(),
+		Aud:          aud,
 		Email:        email,
 		UserMetaData: userData,
 	}

--- a/storage/sql/user.go
+++ b/storage/sql/user.go
@@ -63,3 +63,11 @@ func (u *UserObj) BeforeUpdate() (err error) {
 
 	return err
 }
+
+func (conn *Connection) newUserObj(user *models.User) *UserObj {
+	return &UserObj{
+		User:           user,
+		FirstRoleName:  conn.config.JWT.AdminGroupName,
+		AutoAsignRoles: !conn.config.JWT.AdminGroupDisabled,
+	}
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -7,14 +7,14 @@ type Connection interface {
 	Automigrate() error
 	CreateUser(user *models.User) error
 	FindUserByConfirmationToken(token string) (*models.User, error)
-	FindUserByEmail(email string) (*models.User, error)
+	FindUserByEmailAndAudience(email, aud string) (*models.User, error)
 	FindUserByID(id string) (*models.User, error)
 	FindUserByRecoveryToken(token string) (*models.User, error)
-	FindUserWithRefreshToken(token string) (*models.User, *models.RefreshToken, error)
+	FindUserWithRefreshToken(token, aud string) (*models.User, *models.RefreshToken, error)
 	GrantAuthenticatedUser(user *models.User) (*models.RefreshToken, error)
 	GrantRefreshTokenSwap(user *models.User, token *models.RefreshToken) (*models.RefreshToken, error)
-	IsDuplicatedEmail(email, id string) (bool, error)
-	Logout(id interface{})
+	IsDuplicatedEmail(email, aud, id string) (bool, error)
+	Logout(id string)
 	RevokeToken(token *models.RefreshToken) error
 	RollbackRefreshTokenSwap(newToken, oldToken *models.RefreshToken) error
 	UpdateUser(user *models.User) error


### PR DESCRIPTION
This implements multitenancy with JWT aud support.
Users can be created in different audiences and tokens
will be issued for a specific audience.

Fixes #14 

Signed-off-by: David Calavera <david.calavera@gmail.com>