### PR TITLE
Turn notifications off and update Travis to Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,13 @@ addons:
       - mongodb-org-server
 
 go:
-  - 1.7
+  - 1.8
 
 env:
   - NETLIFY_AUTH_MONGODB_TEST_CONN_URL=127.0.0.1
 
 install: make deps
 script: make all
+
+notifications:
+    email: false


### PR DESCRIPTION
These notifications are killing my inbox.
The project should still work with Go 1.8.

Signed-off-by: David Calavera <david.calavera@gmail.com>