### PR TITLE
Use rand.Reader directly instead of relying upon uuid

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -1,16 +1,19 @@
 package crypto
 
 import (
+	"crypto/rand"
 	"encoding/base64"
+	"io"
 	"strings"
-
-	"github.com/pborman/uuid"
 )
 
 // SecureToken creates a new random token
 func SecureToken() string {
-	token := uuid.NewRandom()
-	return removePadding(base64.URLEncoding.EncodeToString([]byte(token)))
+	b := make([]byte, 16)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		panic(err.Error()) // rand should never fail
+	}
+	return removePadding(base64.URLEncoding.EncodeToString(b))
 }
 
 func removePadding(token string) string {


### PR DESCRIPTION
**- Summary**

uuid did some bit manipulation so only guaranteed 122 bits of random data. This change gets us the full 128 bits.

**- Test plan**

Tests pass.

**- Description for the changelog**

Use rand.Reader directly for full 128 bits of random data.

**- A picture of a cute animal (not mandatory but encouraged)**
