### PR TITLE
Add default paths for email template URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ If you do not require email confirmation, you may set this to `true`. Defaults t
 
 The folder on `site_url` where the `confirm`, `recover`, and `confirm-email`
 pages are located. This is used in combination with `site_url` to generate the 
-URLs used in the emails.
+URLs used in the emails. Defaults to `/member`.
 
 `mailer.subjects.confirmation` - `string`
 
@@ -256,10 +256,10 @@ Email subject to use for email change confirmation. Defaults to `Confirm Email C
 
 `mailer.templates.confirmation` - `string`
 
-Email template when confirming a signup.
+URL path to an email template to use when confirming a signup. Defaults to `/.netlify/gotrue/templates/confirm.html`
 `SiteURL`, `Email`, and `ConfirmationURL` variables are available.
 
-Default:
+Default Content (if template is unavailable):
 ```html
 <h2>Confirm your signup</h2>
 
@@ -269,10 +269,10 @@ Default:
 
 `mailer.templates.recovery` - `string`
 
-Email template when resetting a password.
+URL path to an email template to use when resetting a password. Defaults to `/.netlify/gotrue/templates/recover.html`
 `SiteURL`, `Email`, and `ConfirmationURL` variables are available.
 
-Default:
+Default Content (if template is unavailable):
 ```html
 <h2>Reset Password</h2>
 
@@ -282,10 +282,10 @@ Default:
 
 `mailer.templates.email_change` - `string`
 
-Email template when confirming the change of an email address.
+URL path to an email template to use when confirming the change of an email address. Defaults to `/.netlify/gotrue/templates/email-change.html`
 `SiteURL`, `Email`, `NewEmail`, and `ConfirmationURL` variables are available.
 
-Default:
+Default Content (if template is unavailable):
 ```html
 <h2>Confirm Change of Email</h2>
 

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -133,6 +133,11 @@ func LoadConfig(cmd *cobra.Command) (*Configuration, error) {
 		return nil, err
 	}
 
+	config.ApplyDefaults()
+	return config, nil
+}
+
+func (config *Configuration) ApplyDefaults() {
 	if config.JWT.AdminGroupName == "" {
 		config.JWT.AdminGroupName = "admin"
 	}
@@ -145,5 +150,17 @@ func LoadConfig(cmd *cobra.Command) (*Configuration, error) {
 		config.Mailer.MaxFrequency = 15 * time.Minute
 	}
 
-	return config, nil
+	if config.Mailer.MemberFolder == "" {
+		config.Mailer.MemberFolder = "/member"
+	}
+
+	if config.Mailer.Templates.Confirmation == "" {
+		config.Mailer.Templates.Confirmation = "/.netlify/gotrue/templates/confirm.html"
+	}
+	if config.Mailer.Templates.Recovery == "" {
+		config.Mailer.Templates.Recovery = "/.netlify/gotrue/templates/recover.html"
+	}
+	if config.Mailer.Templates.EmailChange == "" {
+		config.Mailer.Templates.EmailChange = "/.netlify/gotrue/templates/email-change.html"
+	}
 }

--- a/mailer/mailer_test.go
+++ b/mailer/mailer_test.go
@@ -1,0 +1,30 @@
+package mailer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSiteURL(t *testing.T) {
+	cases := []struct {
+		SiteURL  string
+		Folder   string
+		Filename string
+		Expected string
+	}{
+		{"https://test.example.com", "/.netlify/gotrue/templates", "confirm.html", "https://test.example.com/.netlify/gotrue/templates/confirm.html"},
+		{"https://test.example.com/removedpath", "/.netlify/gotrue/templates", "confirm.html", "https://test.example.com/.netlify/gotrue/templates/confirm.html"},
+		{"https://test.example.com/", "/trailingslash/", "confirm.html", "https://test.example.com/trailingslash/confirm.html"},
+		{"https://test.example.com/", "/f/", "/extrafolder/confirm.html", "https://test.example.com/f/extrafolder/confirm.html"},
+		{"https://test.example.com/", "f/", "/confirm.html", "https://test.example.com/f/confirm.html"},
+		{"https://test.example.com/", "f", "/confirm.html", "https://test.example.com/f/confirm.html"},
+		{"https://test.example.com", "f", "confirm.html", "https://test.example.com/f/confirm.html"},
+	}
+
+	for _, c := range cases {
+		act, err := getSiteURL(c.SiteURL, c.Folder, c.Filename)
+		assert.NoError(t, err, c.Expected)
+		assert.Equal(t, c.Expected, act)
+	}
+}

--- a/models/instance.go
+++ b/models/instance.go
@@ -79,6 +79,7 @@ func (i *Instance) ConfigForEnvironment(env string) (*conf.Configuration, error)
 	if err := mergo.MergeWithOverwrite(&baseConf, i.BaseConfig); err != nil {
 		return nil, err
 	}
+	baseConf.ApplyDefaults()
 
 	if i.Contexts != nil {
 		envConf, ok := i.Contexts[env]


### PR DESCRIPTION
Fixes #42

**- Summary**

Add default paths for email template URLs.

**- Test plan**

Added tests for template URL construction.

**- Description for the changelog**

Add default paths for email template URLs.
