### PR TITLE
Add user invites

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ The folder on `site_url` where the `confirm`, `recover`, and `confirm-email`
 pages are located. This is used in combination with `site_url` to generate the 
 URLs used in the emails. Defaults to `/member`.
 
+`mailer.subjects.invite` - `string`
+
+Email subject to use for user invite. Defaults to `You have been invited`.
+
 `mailer.subjects.confirmation` - `string`
 
 Email subject to use for signup confirmation. Defaults to `Confirm Your Signup`.
@@ -253,6 +257,19 @@ Email subject to use for password reset. Defaults to `Reset Your Password`.
 `mailer.subjects.email_change` - `string`
 
 Email subject to use for email change confirmation. Defaults to `Confirm Email Change`.
+
+`mailer.templates.invite` - `string`
+
+URL path to an email template to use when inviting a user. Defaults to `/.netlify/gotrue/templates/invite.html`
+`SiteURL`, `Email`, and `ConfirmationURL` variables are available.
+
+Default Content (if template is unavailable):
+```html
+<h2>You have been invited</h2>
+
+<p>You have been invited to create a user on {{ .SiteURL }}. Follow this link to accept the invite:</p>
+<p><a href="{{ .ConfirmationURL }}">Accept the invite</a></p>
+```
 
 `mailer.templates.confirmation` - `string`
 

--- a/api/api.go
+++ b/api/api.go
@@ -66,6 +66,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 		}
 
 		r.Post("/signup", api.Signup)
+		r.Post("/invite", api.Invite)
 		r.Post("/recover", api.Recover)
 		r.Post("/verify", api.Verify)
 		r.Post("/token", api.Token)

--- a/api/invite.go
+++ b/api/invite.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/netlify/gotrue/models"
+)
+
+// InviteParams are the parameters the Signup endpoint accepts
+type InviteParams struct {
+	Email string                 `json:"email"`
+	Data  map[string]interface{} `json:"data"`
+}
+
+// Invite is the endpoint for inviting a new user
+func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	config := getConfig(ctx)
+	instanceID := getInstanceID(ctx)
+	params := &InviteParams{}
+
+	jsonDecoder := json.NewDecoder(r.Body)
+	err := jsonDecoder.Decode(params)
+	if err != nil {
+		return badRequestError("Could not read Invite params: %v", err)
+	}
+
+	if params.Email == "" {
+		return unprocessableEntityError("Invite requires a valid email")
+	}
+
+	aud := a.requestAud(ctx, r)
+
+	user, err := a.db.FindUserByEmailAndAudience(instanceID, params.Email, aud)
+	if err == nil {
+		return unprocessableEntityError("Email address already registered by another user")
+	}
+	if !models.IsNotFoundError(err) {
+		return internalServerError("Database error finding user").WithInternalError(err)
+	}
+
+	signupParams := SignupParams{
+		Email: params.Email,
+		Data:  params.Data,
+	}
+
+	user, err = a.signupNewUser(ctx, &signupParams, aud)
+	if err != nil {
+		return err
+	}
+	user.InvitedAt = time.Now()
+
+	mailer := getMailer(ctx)
+	if err = mailer.ValidateEmail(params.Email); err != nil {
+		return unprocessableEntityError("Unable to validate email address: " + err.Error())
+	}
+
+	if user.ConfirmationSentAt.Add(config.Mailer.MaxFrequency).Before(time.Now()) {
+		if err := mailer.InviteMail(user); err != nil {
+			return internalServerError("Error sending confirmation mail").WithInternalError(err)
+		}
+	}
+
+	user.SetRole(config.JWT.DefaultGroupName)
+	if err = a.db.UpdateUser(user); err != nil {
+		return internalServerError("Database error updating user").WithInternalError(err)
+	}
+
+	return sendJSON(w, http.StatusOK, user)
+}

--- a/api/invite_test.go
+++ b/api/invite_test.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/netlify/gotrue/conf"
+	"github.com/netlify/gotrue/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type InviteTestSuite struct {
+	suite.Suite
+	API    *API
+	Config *conf.Configuration
+}
+
+func (ts *InviteTestSuite) SetupTest() {
+	api, err := NewAPIFromConfigFile("config.test.json", "v1")
+	require.NoError(ts.T(), err)
+
+	ts.API = api
+
+	config, err := conf.LoadConfigFromFile("config.test.json")
+	require.NoError(ts.T(), err)
+	ts.Config = config
+
+	// Cleanup existing user
+	u, err := ts.API.db.FindUserByEmailAndAudience("", "test@example.com", config.JWT.Aud)
+	if err == nil {
+		require.NoError(ts.T(), api.db.DeleteUser(u))
+	}
+}
+
+func (ts *InviteTestSuite) TestInvite() {
+	// Request body
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"email": "test@example.com",
+		"data": map[string]interface{}{
+			"a": 1,
+		},
+	}))
+
+	// Setup request
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/invite", &buffer)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Setup response recorder
+	w := httptest.NewRecorder()
+
+	ts.API.handler.ServeHTTP(w, req)
+	assert.Equal(ts.T(), w.Code, http.StatusOK)
+}
+
+func (ts *InviteTestSuite) TestVerifyInvite() {
+	user, err := models.NewUser("", "test@example.com", "", ts.Config.JWT.Aud, nil)
+	user.InvitedAt = time.Now()
+	user.EncryptedPassword = ""
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.CreateUser(user))
+
+	// Find test user
+	u, err := ts.API.db.FindUserByEmailAndAudience("", "test@example.com", ts.Config.JWT.Aud)
+	require.NoError(ts.T(), err)
+
+	// Request body
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"type":     "signup",
+		"token":    u.ConfirmationToken,
+		"password": "testing",
+	}))
+
+	// Setup request
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/verify", &buffer)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Setup response recorder
+	w := httptest.NewRecorder()
+
+	ts.API.handler.ServeHTTP(w, req)
+
+	assert.Equal(ts.T(), w.Code, http.StatusOK)
+}
+
+func (ts *InviteTestSuite) TestVerifyInvite_NoPassword() {
+	user, err := models.NewUser("", "test@example.com", "", ts.Config.JWT.Aud, nil)
+	user.InvitedAt = time.Now()
+	user.EncryptedPassword = ""
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.CreateUser(user))
+
+	// Find test user
+	u, err := ts.API.db.FindUserByEmailAndAudience("", "test@example.com", ts.Config.JWT.Aud)
+	require.NoError(ts.T(), err)
+
+	// Request body
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"type":  "signup",
+		"token": u.ConfirmationToken,
+	}))
+
+	// Setup request
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/verify", &buffer)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Setup response recorder
+	w := httptest.NewRecorder()
+
+	ts.API.handler.ServeHTTP(w, req)
+
+	assert.Equal(ts.T(), w.Code, http.StatusUnprocessableEntity)
+}
+
+func TestInvite(t *testing.T) {
+	suite.Run(t, new(InviteTestSuite))
+}

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -66,7 +66,7 @@ func (ts *SignupTestSuite) TestSignup() {
 	assert.Equal(ts.T(), data["email"], "test@example.com")
 	assert.Equal(ts.T(), data["aud"], ts.Config.JWT.Aud)
 	assert.Equal(ts.T(), data["user_metadata"].(map[string]interface{})["a"], 1.0)
-	assert.Len(ts.T(), data, 12)
+	assert.Len(ts.T(), data, 13)
 }
 
 // TestSignupExternalUnsupported tests API /signup for an unsupported external provider
@@ -151,7 +151,6 @@ func (ts *SignupTestSuite) TestSignupExternalGitlab() {
 	if code == "" || ts.Config.External.Gitlab.Secret == "" {
 		ts.T().Skip("GOTRUE_GITLAB_OAUTH_CODE or Gitlab external provider config not set")
 		return
-
 	}
 
 	// Request body

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -63,11 +63,13 @@ type Configuration struct {
 		MemberFolder string        `json:"member_folder"`
 		AdminEmail   string        `json:"admin_email"`
 		Subjects     struct {
+			Invite       string `json:"invite"`
 			Confirmation string `json:"confirmation"`
 			Recovery     string `json:"recovery"`
 			EmailChange  string `json:"email_change"`
 		} `json:"subjects"`
 		Templates struct {
+			Invite       string `json:"invite"`
 			Confirmation string `json:"confirmation"`
 			Recovery     string `json:"recovery"`
 			EmailChange  string `json:"email_change"`
@@ -154,6 +156,9 @@ func (config *Configuration) ApplyDefaults() {
 		config.Mailer.MemberFolder = "/member"
 	}
 
+	if config.Mailer.Templates.Invite == "" {
+		config.Mailer.Templates.Invite = "/.netlify/gotrue/templates/invite.html"
+	}
 	if config.Mailer.Templates.Confirmation == "" {
 		config.Mailer.Templates.Confirmation = "/.netlify/gotrue/templates/confirm.html"
 	}

--- a/models/user.go
+++ b/models/user.go
@@ -20,6 +20,7 @@ type User struct {
 	Email             string    `json:"email" bson:"email"`
 	EncryptedPassword string    `json:"-" bson:"encrypted_password"`
 	ConfirmedAt       time.Time `json:"confirmed_at" bson:"confirmed_at"`
+	InvitedAt         time.Time `json:"invited_at" bson:"invited_at"`
 
 	ConfirmationToken  string    `json:"-" bson:"confirmation_token,omitempty"`
 	ConfirmationSentAt time.Time `json:"confirmation_sent_at,omitempty" bson:"confirmation_sent_at,omitempty"`


### PR DESCRIPTION
Fixes #43 

**- Summary**

Add the ability to invite a user and have them set a password when confirming their email. This ignores the `Autoconfirm` setting because they need to receive an email and set a password. This process does not allow the use of external providers.

**- Test plan**

Added some basic tests of functionality

**- Description for the changelog**

Add user invites.