### PR TITLE
Add support for Google Cloud SQL Postgres

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -20,6 +20,7 @@ type ExternalConfiguration struct {
 
 // DBConfiguration holds all the database related configuration.
 type DBConfiguration struct {
+	Dialect     string `json:"dialect"`
 	Driver      string `json:"driver"`
 	ConnURL     string `json:"url"`
 	Namespace   string `json:"namespace"`

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,10 @@
-hash: 32abf8e629238d235054f91bb495cea33b42e74dc0b5284166c522b7b0c740b3
-updated: 2017-08-16T16:19:03.149952969-04:00
+hash: 7260ab4358d6b13da349498b1a52a696379b3a46cee69f2704e0203a53beefe0
+updated: 2017-08-16T19:19:29.089891255-04:00
 imports:
+- name: cloud.google.com/go
+  version: 06f11fffc537c4aef126d9fd3a92e2d7968f118f
+  subpackages:
+  - compute/metadata
 - name: github.com/badoux/checkmail
   version: d0a759655d62bcdc95c50a0676f3e9702ed59453
 - name: github.com/davecgh/go-spew
@@ -21,6 +25,14 @@ imports:
   version: ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e
   subpackages:
   - proto
+- name: github.com/GoogleCloudPlatform/cloudsql-proxy
+  version: 571947b0f240c8b2fa4d163065e5b155920ddfa9
+  subpackages:
+  - logging
+  - proxy/certs
+  - proxy/dialers/postgres
+  - proxy/proxy
+  - proxy/util
 - name: github.com/hashicorp/hcl
   version: 392dba7d905ed5d04a5794ba89f558b27e2ba1ca
   subpackages:
@@ -139,7 +151,10 @@ imports:
   subpackages:
   - bitbucket
   - github
+  - google
   - internal
+  - jws
+  - jwt
 - name: golang.org/x/sys
   version: 9f7170bcd8e9f4d3691c06401119c46a769a1e03
   subpackages:
@@ -149,13 +164,22 @@ imports:
   subpackages:
   - transform
   - unicode/norm
+- name: google.golang.org/api
+  version: 98825bb0065da4054e5da6db34f5fc598e50bc24
+  subpackages:
+  - gensupport
+  - googleapi
+  - googleapi/internal/uritemplates
+  - sqladmin/v1beta4
 - name: google.golang.org/appengine
   version: d9a072cfa7b9736e44311ef77b3e09d804bfa599
   subpackages:
   - internal
+  - internal/app_identity
   - internal/base
   - internal/datastore
   - internal/log
+  - internal/modules
   - internal/remote_api
   - internal/urlfetch
   - urlfetch

--- a/glide.yaml
+++ b/glide.yaml
@@ -50,3 +50,7 @@ import:
 - package: github.com/imdario/mergo
   version: 0.2.2
 - package: github.com/sebest/xff
+- package: github.com/GoogleCloudPlatform/cloudsql-proxy
+  version: "1.10"
+  subpackages:
+  - proxy/dialers/postgres

--- a/storage/sql/storage.go
+++ b/storage/sql/storage.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	// import drivers we might need
+	_ "github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/dialers/postgres"
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
@@ -294,7 +295,10 @@ func Dial(config *conf.GlobalConfiguration) (*Connection, error) {
 		config.DB.Driver = u.Scheme
 	}
 
-	db, err := gorm.Open(config.DB.Driver, config.DB.ConnURL)
+	if config.DB.Dialect == "" {
+		config.DB.Dialect = config.DB.Driver
+	}
+	db, err := gorm.Open(config.DB.Dialect, config.DB.Driver, config.DB.ConnURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "opening database connection")
 	}


### PR DESCRIPTION
**- Summary**

Add support for Google Cloud SQL Postgres. We still need `gorm` to use the `postgres` dialect, so we needed to separate that out from the `driver` in configuration. 

**- Test plan**

Manual testing.

**- Description for the changelog**

Add support for Google Cloud SQL Postgres.

