### PR TITLE
Allow Admin requests with an operator token.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -86,8 +86,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 
 		r.Route("/admin", func(r *router) {
 			r.Use(addGetBody)
-			r.Use(api.requireAuthentication)
-			r.Use(api.requireAdmin)
+			r.Use(api.requireAdminCredentials)
 
 			r.Get("/users", api.adminUsers)
 
@@ -99,10 +98,10 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 	})
 
 	if globalConfig.MultiInstanceMode {
-		// Netlify microservice API
-		r.With(api.verifyNetlifyRequest).Get("/", api.GetAppManifest)
+		// Operator microservice API
+		r.With(api.verifyOperatorRequest).Get("/", api.GetAppManifest)
 		r.Route("/instances", func(r *router) {
-			r.Use(api.verifyNetlifyRequest)
+			r.Use(api.verifyOperatorRequest)
 
 			r.Post("/", api.CreateInstance)
 			r.Route("/{instance_id}", func(r *router) {

--- a/api/config.test.json
+++ b/api/config.test.json
@@ -15,5 +15,6 @@
   },
   "logging": {
     "level": "error"
-  }
+  },
+  "operator_token": "foobar"
 }

--- a/api/instance_test.go
+++ b/api/instance_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 const testUUID = "11111111-1111-1111-1111-111111111111"
-const netlifySecret = "netlifysecret"
+const operatorToken = "operatorToken"
 
 type InstanceTestSuite struct {
 	suite.Suite
@@ -28,7 +28,7 @@ type InstanceTestSuite struct {
 func (ts *InstanceTestSuite) SetupTest() {
 	globalConfig, err := conf.LoadGlobalFromFile("config.test.json")
 	require.NoError(ts.T(), err)
-	globalConfig.NetlifySecret = netlifySecret
+	globalConfig.OperatorToken = operatorToken
 	globalConfig.MultiInstanceMode = true
 	db, err := dial.Dial(globalConfig)
 	require.NoError(ts.T(), err)
@@ -66,7 +66,7 @@ func (ts *InstanceTestSuite) TestCreate() {
 	// Setup request
 	req := httptest.NewRequest(http.MethodPost, "http://localhost/instances", &buffer)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+netlifySecret)
+	req.Header.Set("Authorization", "Bearer "+operatorToken)
 
 	// Setup response recorder
 	w := httptest.NewRecorder()
@@ -101,7 +101,7 @@ func (ts *InstanceTestSuite) TestGet() {
 
 	req := httptest.NewRequest(http.MethodGet, "http://localhost/instances/"+instanceID, nil)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+netlifySecret)
+	req.Header.Set("Authorization", "Bearer "+operatorToken)
 
 	w := httptest.NewRecorder()
 	ts.API.handler.ServeHTTP(w, req)

--- a/cmd/multi_cmd.go
+++ b/cmd/multi_cmd.go
@@ -24,8 +24,8 @@ func multi(cmd *cobra.Command, args []string) {
 	if err != nil {
 		logrus.Fatalf("Failed to load configration: %+v", err)
 	}
-	if globalConfig.NetlifySecret == "" {
-		logrus.Fatal("Netlify microservice secret is required")
+	if globalConfig.OperatorToken == "" {
+		logrus.Fatal("Operator token secret is required")
 	}
 
 	var db storage.Connection

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -46,7 +46,7 @@ type GlobalConfiguration struct {
 	} `json:"api"`
 	DB                DBConfiguration     `json:"db"`
 	Logging           nconf.LoggingConfig `json:"log_conf"`
-	NetlifySecret     string              `json:"netlify_secret"`
+	OperatorToken     string              `json:"operator_token"`
 	MultiInstanceMode bool                `json:"-"`
 }
 


### PR DESCRIPTION
- Rename NetlifySecret to OperatorToken.
- Check operator token match before running admin operations.

Signed-off-by: David Calavera <david.calavera@gmail.com>