### PR TITLE
Fix reference to netlifySecret.

### DIFF
--- a/api/instance_test.go
+++ b/api/instance_test.go
@@ -149,7 +149,7 @@ func (ts *InstanceTestSuite) TestUpdate() {
 
 	req := httptest.NewRequest(http.MethodPut, "http://localhost/instances/"+instanceID, &buffer)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+netlifySecret)
+	req.Header.Set("Authorization", "Bearer "+operatorToken)
 
 	w := httptest.NewRecorder()
 	ts.API.handler.ServeHTTP(w, req)


### PR DESCRIPTION
This reference was missing after merging two different PRs.

Signed-off-by: David Calavera <david.calavera@gmail.com>