### PR TITLE
Preload audience from the request before getting a user.

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -76,12 +76,19 @@ func (api *API) adminUsers(w http.ResponseWriter, r *http.Request) error {
 
 // adminUserGet returns information about a single user
 func (api *API) adminUserGet(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
 	instanceID := getInstanceID(r.Context())
+
+	aud := r.FormValue("aud")
+	if aud == "" {
+		aud = api.requestAud(ctx, r)
+	}
+
 	params := &adminUserParams{
 		User: adminTargetUser{
 			ID:    r.FormValue("id"),
 			Email: r.FormValue("email"),
-			Aud:   r.FormValue("aud"),
+			Aud:   aud,
 		},
 	}
 	user, err := api.getAdminTargetUser(instanceID, params)


### PR DESCRIPTION
Keep support for the request parameter when it's still in the request,
but fallback to other claims if it's not in the request.

Signed-off-by: David Calavera <david.calavera@gmail.com>