### PR TITLE
Get name and avatar URL from external providers

### DIFF
--- a/api/provider/bitbucket.go
+++ b/api/provider/bitbucket.go
@@ -2,7 +2,9 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/netlify/gotrue/conf"
 	"golang.org/x/oauth2"
@@ -30,16 +32,52 @@ func (g bitbucketProvider) GetOAuthToken(ctx context.Context, code string) (*oau
 	return g.Exchange(ctx, code)
 }
 
-func (g bitbucketProvider) GetUserEmail(ctx context.Context, tok *oauth2.Token) (string, error) {
+func (g bitbucketProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {
 	u := struct {
 		User struct {
-			Username string `json:"username"`
+			Username  string `json:"username"`
+			FirstName string `json:"first_name"`
+			LastName  string `json:"last_name"`
+			AvatarURL string `json:"avatar"`
 		}
 	}{}
 
 	if err := makeRequest(ctx, tok, g.Config, "https://api.bitbucket.org/1.0/user", &u); err != nil {
+		return nil, err
+	}
+
+	email, err := getUserEmail(ctx, tok, g.Config, fmt.Sprintf("https://api.bitbucket.org/1.0/users/%s/emails", u.User.Username))
+	if err != nil {
+		return nil, err
+	}
+
+	name := strings.TrimSpace(strings.Join([]string{u.User.FirstName, u.User.LastName}, " "))
+
+	return &UserProvidedData{
+		Email: email,
+		Metadata: map[string]string{
+			nameKey:      name,
+			avatarURLKey: u.User.AvatarURL,
+		},
+	}, nil
+}
+
+func getUserEmail(ctx context.Context, tok *oauth2.Token, g *oauth2.Config, url string) (string, error) {
+	emails := []struct {
+		Primary bool   `json:"primary"`
+		Email   string `json:"email"`
+	}{}
+
+	if err := makeRequest(ctx, tok, g, url, &emails); err != nil {
 		return "", err
 	}
 
-	return getUserEmail(ctx, tok, g.Config, fmt.Sprintf("https://api.bitbucket.org/1.0/users/%s/emails", u.User.Username))
+	for _, v := range emails {
+		if !v.Primary {
+			continue
+		}
+		return v.Email, nil
+	}
+
+	return "", errors.New("No email address returned by API call to " + url)
 }

--- a/api/provider/github.go
+++ b/api/provider/github.go
@@ -29,6 +29,23 @@ func (g githubProvider) GetOAuthToken(ctx context.Context, code string) (*oauth2
 	return g.Exchange(ctx, code)
 }
 
-func (g githubProvider) GetUserEmail(ctx context.Context, tok *oauth2.Token) (string, error) {
-	return getUserEmail(ctx, tok, g.Config, "https://api.github.com/user/emails")
+func (g githubProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {
+	u := struct {
+		Email     string `json:"email"`
+		Username  string `json:"username"`
+		Name      string `json:"name"`
+		AvatarURL string `json:"avatar_url"`
+	}{}
+
+	if err := makeRequest(ctx, tok, g.Config, "https://api.github.com/user", &u); err != nil {
+		return nil, err
+	}
+
+	return &UserProvidedData{
+		Email: u.Email,
+		Metadata: map[string]string{
+			nameKey:      u.Name,
+			avatarURLKey: u.AvatarURL,
+		},
+	}, nil
 }

--- a/api/provider/gitlab.go
+++ b/api/provider/gitlab.go
@@ -83,14 +83,22 @@ func (g gitlabProvider) GetOAuthToken(ctx context.Context, code string) (*oauth2
 	return dst, nil
 }
 
-func (g gitlabProvider) GetUserEmail(ctx context.Context, tok *oauth2.Token) (string, error) {
+func (g gitlabProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {
 	user := struct {
-		Email string `json:"email"`
+		Email     string `json:"email"`
+		Name      string `json:"name"`
+		AvatarURL string `json:"avatar_url"`
 	}{}
 
 	if err := makeRequest(ctx, tok, g.Config, "https://gitlab.com/api/v4/user", &user); err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return user.Email, nil
+	return &UserProvidedData{
+		Email: user.Email,
+		Metadata: map[string]string{
+			nameKey:      user.Name,
+			avatarURLKey: user.AvatarURL,
+		},
+	}, nil
 }

--- a/api/provider/provider.go
+++ b/api/provider/provider.go
@@ -3,35 +3,24 @@ package provider
 import (
 	"context"
 	"encoding/json"
-	"errors"
 
 	"golang.org/x/oauth2"
 )
 
-// Provider is an interface for interacting with external account providers
-type Provider interface {
-	GetUserEmail(context.Context, *oauth2.Token) (string, error)
-	GetOAuthToken(context.Context, string) (*oauth2.Token, error)
+const (
+	avatarURLKey = "avatar_url"
+	nameKey      = "name"
+)
+
+type UserProvidedData struct {
+	Email    string
+	Metadata map[string]string
 }
 
-func getUserEmail(ctx context.Context, tok *oauth2.Token, g *oauth2.Config, url string) (string, error) {
-	emails := []struct {
-		Primary bool   `json:"primary"`
-		Email   string `json:"email"`
-	}{}
-
-	if err := makeRequest(ctx, tok, g, url, &emails); err != nil {
-		return "", err
-	}
-
-	for _, v := range emails {
-		if !v.Primary {
-			continue
-		}
-		return v.Email, nil
-	}
-
-	return "", errors.New("No email address returned by API call to " + url)
+// Provider is an interface for interacting with external account providers
+type Provider interface {
+	GetUserData(context.Context, *oauth2.Token) (*UserProvidedData, error)
+	GetOAuthToken(context.Context, string) (*oauth2.Token, error)
 }
 
 func makeRequest(ctx context.Context, tok *oauth2.Token, g *oauth2.Config, url string, dst interface{}) error {

--- a/api/token.go
+++ b/api/token.go
@@ -89,14 +89,14 @@ func (a *API) AuthorizationCodeGrant(ctx context.Context, w http.ResponseWriter,
 		return internalServerError("Unable to authenticate via %s", providerName).WithInternalError(err).WithInternalMessage("Error exchanging code with external provider")
 	}
 
-	email, err := provider.GetUserEmail(ctx, tok)
+	data, err := provider.GetUserData(ctx, tok)
 	if err != nil {
 		return internalServerError("Error getting user email from %s", providerName).WithInternalError(err).WithInternalMessage("Error getting email address from external provider")
 	}
 
 	aud := a.requestAud(ctx, r)
 	instanceID := getInstanceID(ctx)
-	user, err := a.db.FindUserByEmailAndAudience(instanceID, email, aud)
+	user, err := a.db.FindUserByEmailAndAudience(instanceID, data.Email, aud)
 	if err != nil {
 		return internalServerError(err.Error())
 	}


### PR DESCRIPTION
Fixes #54 

**- Summary**

We need more metadata to create a good front end experience. This retrieves a user's name and avatar URL from external providers.

**- Test plan**

Existing tests pass.

**- Description for the changelog**

Retrieve user name and avatar URL from external providers.
