### PR TITLE
Add google external provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The default group to assign all new users to.
 
 ### External Authentication Providers
 
-We support `github`, `gitlab`, and `bitbucket` for external authentication.
+We support `bitbucket`, `github`, `gitlab`, and `google` for external authentication.
 Use the names as the keys underneath `external` to configure each separately.
 
 ```

--- a/api/api.go
+++ b/api/api.go
@@ -168,12 +168,14 @@ func (a *API) Provider(ctx context.Context, name string) (provider.Provider, err
 	name = strings.ToLower(name)
 
 	switch name {
-	case "github":
-		return provider.NewGithubProvider(config.External.Github), nil
 	case "bitbucket":
 		return provider.NewBitbucketProvider(config.External.Bitbucket), nil
+	case "github":
+		return provider.NewGithubProvider(config.External.Github), nil
 	case "gitlab":
 		return provider.NewGitlabProvider(config.External.Gitlab), nil
+	case "google":
+		return provider.NewGoogleProvider(config.External.Google), nil
 	default:
 		return nil, fmt.Errorf("Provider %s could not be found", name)
 	}

--- a/api/provider/google.go
+++ b/api/provider/google.go
@@ -1,0 +1,63 @@
+package provider
+
+import (
+	"context"
+	"errors"
+
+	"github.com/netlify/gotrue/conf"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+type googleProvider struct {
+	*oauth2.Config
+}
+
+// NewGoogleProvider creates a Google account provider.
+func NewGoogleProvider(ext conf.ExternalConfiguration) Provider {
+	return &googleProvider{
+		&oauth2.Config{
+			ClientID:     ext.ClientID,
+			ClientSecret: ext.Secret,
+			Endpoint:     google.Endpoint,
+			Scopes:       []string{"profile", "email"},
+		},
+	}
+}
+
+func (g googleProvider) GetOAuthToken(ctx context.Context, code string) (*oauth2.Token, error) {
+	return g.Exchange(ctx, code)
+}
+
+func (g googleProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {
+	u := struct {
+		Name   string `json:"displayName"`
+		Avatar struct {
+			URL string `json:"url"`
+		} `json:"image"`
+		Emails []struct {
+			Type  string `json:"type"`
+			Value string `json:"value"`
+		} `json:"emails"`
+	}{}
+
+	if err := makeRequest(ctx, tok, g.Config, "https://www.googleapis.com/plus/v1/people/me", &u); err != nil {
+		return nil, err
+	}
+
+	var email string
+	if len(u.Emails) > 0 {
+		email = u.Emails[0].Value
+	}
+	if email == "" {
+		return nil, errors.New("No email address returned by Google")
+	}
+
+	return &UserProvidedData{
+		Email: email,
+		Metadata: map[string]string{
+			nameKey:      u.Name,
+			avatarURLKey: u.Avatar.URL,
+		},
+	}, nil
+}

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -171,6 +171,32 @@ func (ts *SignupTestSuite) TestSignupExternalGitlab() {
 	assert.Equal(ts.T(), w.Code, http.StatusOK)
 }
 
+// TestSignupExternalGoogle tests API /signup for google
+func (ts *SignupTestSuite) TestSignupExternalGoogle() {
+	code := os.Getenv("GOTRUE_GOOGLE_OAUTH_CODE")
+	if code == "" || ts.Config.External.Google.Secret == "" {
+		ts.T().Skip("GOTRUE_GOOGLE_OAUTH_CODE or Google external provider config not set")
+		return
+	}
+
+	// Request body
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"provider": "google",
+		"code":     code,
+	}))
+
+	// Setup request
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/signup", &buffer)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Setup response recorder
+	w := httptest.NewRecorder()
+
+	ts.API.handler.ServeHTTP(w, req)
+	assert.Equal(ts.T(), w.Code, http.StatusOK)
+}
+
 // TestSignupTwice checks to make sure the same email cannot be registered twice
 func (ts *SignupTestSuite) TestSignupTwice() {
 	// Request body

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -73,9 +73,10 @@ type Configuration struct {
 		Templates    EmailContentConfiguration `json:"templates"`
 	} `json:"mailer"`
 	External struct {
-		Github    ExternalConfiguration `json:"github"`
 		Bitbucket ExternalConfiguration `json:"bitbucket"`
+		Github    ExternalConfiguration `json:"github"`
 		Gitlab    ExternalConfiguration `json:"gitlab"`
+		Google    ExternalConfiguration `json:"google"`
 	} `json:"external"`
 }
 


### PR DESCRIPTION
Fixes #55 

**- Summary**

Support a non-developer centric external auth provider.

**- Test plan**

Added a simple test.

**- Description for the changelog**

Add Google external provider.

