### PR TITLE
Allow to update user data via the admin api.

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -22,12 +22,13 @@ type adminTargetUser struct {
 }
 
 type adminUserParams struct {
-	Role     string                 `json:"role"`
-	Email    string                 `json:"email"`
-	Password string                 `json:"password"`
-	Confirm  bool                   `json:"confirm"`
-	Data     map[string]interface{} `json:"data"`
-	User     adminTargetUser        `json:"user"`
+	Role         string                 `json:"role"`
+	Email        string                 `json:"email"`
+	Password     string                 `json:"password"`
+	Confirm      bool                   `json:"confirm"`
+	UserMetaData map[string]interface{} `json:"user_metadata"`
+	AppMetaData  map[string]interface{} `json:"app_metadata"`
+	User         adminTargetUser        `json:"user"`
 }
 
 func (api *API) getAdminParams(r *http.Request) (*adminUserParams, error) {
@@ -126,6 +127,14 @@ func (api *API) adminUserUpdate(w http.ResponseWriter, r *http.Request) error {
 		user.Email = params.Email
 	}
 
+	if params.AppMetaData != nil {
+		user.UpdateAppMetaData(params.AppMetaData)
+	}
+
+	if params.UserMetaData != nil {
+		user.UpdateUserMetaData(params.UserMetaData)
+	}
+
 	if err := api.db.UpdateUser(user); err != nil {
 		return internalServerError("Error updating user").WithInternalError(err)
 	}
@@ -158,7 +167,7 @@ func (api *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 		return unprocessableEntityError("Email address already registered by another user")
 	}
 
-	user, err := models.NewUser(instanceID, params.Email, params.Password, aud, params.Data)
+	user, err := models.NewUser(instanceID, params.Email, params.Password, aud, params.UserMetaData)
 	if err != nil {
 		return internalServerError("Error creating user").WithInternalError(err)
 	}

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -142,6 +142,12 @@ func (ts *AdminTestSuite) TestAdminUserUpdate() {
 	var buffer bytes.Buffer
 	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
 		"role": "testing",
+		"app_metadata": map[string]interface{}{
+			"roles": []string{"writer", "editor"},
+		},
+		"user_metadata": map[string]interface{}{
+			"name": "David",
+		},
 		"user": map[string]interface{}{
 			"email": "test1@example.com",
 			"aud":   ts.Config.JWT.Aud,
@@ -167,6 +173,10 @@ func (ts *AdminTestSuite) TestAdminUserUpdate() {
 	u, err := ts.API.db.FindUserByEmailAndAudience("", "test1@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	assert.Equal(ts.T(), u.Role, "testing")
+	assert.Equal(ts.T(), u.UserMetaData["name"], "David")
+	assert.Len(ts.T(), u.AppMetaData["roles"], 2)
+	assert.Contains(ts.T(), u.AppMetaData["roles"], "writer")
+	assert.Contains(ts.T(), u.AppMetaData["roles"], "editor")
 }
 
 // TestAdminUserDelete tests API /admin/user route (DELETE)


### PR DESCRIPTION
Change the admin api to let an admin set app and user metadata.

Signed-off-by: David Calavera <david.calavera@gmail.com>