### PR TITLE
Provider metadata

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -171,6 +171,10 @@ func (api *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return internalServerError("Error creating user").WithInternalError(err)
 	}
+	if user.AppMetaData == nil {
+		user.AppMetaData = make(map[string]interface{})
+	}
+	user.AppMetaData["provider"] = "email"
 
 	config := getConfig(ctx)
 	if params.Role != "" {

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -108,10 +108,11 @@ func (ts *AdminTestSuite) TestAdminUserCreate() {
 	u, err := ts.API.db.FindUserByEmailAndAudience("", "test1@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 
-	data := make(map[string]interface{})
+	data := models.User{}
 	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
 
-	assert.Equal(ts.T(), data["email"], u.Email)
+	assert.Equal(ts.T(), u.Email, data.Email)
+	assert.Equal(ts.T(), "email", data.AppMetaData["provider"])
 }
 
 // TestAdminUserGet tests API /admin/user route (GET)

--- a/api/invite.go
+++ b/api/invite.go
@@ -42,8 +42,9 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	signupParams := SignupParams{
-		Email: params.Email,
-		Data:  params.Data,
+		Email:    params.Email,
+		Data:     params.Data,
+		Provider: "email",
 	}
 
 	user, err = a.signupNewUser(ctx, &signupParams, aud)

--- a/api/recover_test.go
+++ b/api/recover_test.go
@@ -31,8 +31,14 @@ func (ts *RecoverTestSuite) SetupTest() {
 	require.NoError(ts.T(), err)
 	ts.Config = config
 
+	// Cleanup existing user
+	u, err := ts.API.db.FindUserByEmailAndAudience("", "test@example.com", config.JWT.Aud)
+	if err == nil {
+		require.NoError(ts.T(), api.db.DeleteUser(u))
+	}
+
 	// Create user
-	u, err := models.NewUser("", "test@example.com", "password", ts.Config.JWT.Aud, nil)
+	u, err = models.NewUser("", "test@example.com", "password", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error creating test user model")
 	require.NoError(ts.T(), api.db.CreateUser(u), "Error saving new test user")
 }

--- a/api/signup.go
+++ b/api/signup.go
@@ -111,6 +111,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 			return unprocessableEntityError("Unable to validate email address: " + err.Error())
 		}
 
+		params.Provider = "email"
 		user, err = a.signupNewUser(ctx, params, aud)
 		if err != nil {
 			return err
@@ -145,6 +146,10 @@ func (a *API) signupNewUser(ctx context.Context, params *SignupParams, aud strin
 	if err != nil {
 		return nil, internalServerError("Database error creating user").WithInternalError(err)
 	}
+	if user.AppMetaData == nil {
+		user.AppMetaData = make(map[string]interface{})
+	}
+	user.AppMetaData["provider"] = params.Provider
 
 	if params.Password == "" {
 		user.EncryptedPassword = ""

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -59,14 +59,14 @@ func (ts *SignupTestSuite) TestSignup() {
 
 	ts.API.handler.ServeHTTP(w, req)
 
-	assert.Equal(ts.T(), w.Code, http.StatusOK)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
 
-	data := make(map[string]interface{})
+	data := models.User{}
 	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
-	assert.Equal(ts.T(), data["email"], "test@example.com")
-	assert.Equal(ts.T(), data["aud"], ts.Config.JWT.Aud)
-	assert.Equal(ts.T(), data["user_metadata"].(map[string]interface{})["a"], 1.0)
-	assert.Len(ts.T(), data, 13)
+	assert.Equal(ts.T(), "test@example.com", data.Email)
+	assert.Equal(ts.T(), ts.Config.JWT.Aud, data.Aud)
+	assert.Equal(ts.T(), 1.0, data.UserMetaData["a"])
+	assert.Equal(ts.T(), "email", data.AppMetaData["provider"])
 }
 
 // TestSignupExternalUnsupported tests API /signup for an unsupported external provider
@@ -115,7 +115,10 @@ func (ts *SignupTestSuite) TestSignupExternalGithub() {
 
 	ts.API.handler.ServeHTTP(w, req)
 
-	assert.Equal(ts.T(), w.Code, http.StatusOK)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+	data := models.User{}
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
+	assert.Equal(ts.T(), "github", data.AppMetaData["provider"])
 }
 
 // TestSignupExternalBitbucket tests API /signup for bitbucket
@@ -142,7 +145,10 @@ func (ts *SignupTestSuite) TestSignupExternalBitbucket() {
 
 	ts.API.handler.ServeHTTP(w, req)
 
-	assert.Equal(ts.T(), w.Code, http.StatusOK)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+	data := models.User{}
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
+	assert.Equal(ts.T(), "bitbucket", data.AppMetaData["provider"])
 }
 
 // TestSignupExternalGitlab tests API /signup for gitlab
@@ -168,7 +174,10 @@ func (ts *SignupTestSuite) TestSignupExternalGitlab() {
 	w := httptest.NewRecorder()
 
 	ts.API.handler.ServeHTTP(w, req)
-	assert.Equal(ts.T(), w.Code, http.StatusOK)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+	data := models.User{}
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
+	assert.Equal(ts.T(), "gitlab", data.AppMetaData["provider"])
 }
 
 // TestSignupExternalGoogle tests API /signup for google
@@ -194,7 +203,10 @@ func (ts *SignupTestSuite) TestSignupExternalGoogle() {
 	w := httptest.NewRecorder()
 
 	ts.API.handler.ServeHTTP(w, req)
-	assert.Equal(ts.T(), w.Code, http.StatusOK)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+	data := models.User{}
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
+	assert.Equal(ts.T(), "google", data.AppMetaData["provider"])
 }
 
 // TestSignupTwice checks to make sure the same email cannot be registered twice

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -32,8 +32,14 @@ func (ts *UserTestSuite) SetupTest() {
 	require.NoError(ts.T(), err)
 	ts.Config = config
 
+	// Cleanup existing user
+	u, err := ts.API.db.FindUserByEmailAndAudience("", "test@example.com", config.JWT.Aud)
+	if err == nil {
+		require.NoError(ts.T(), api.db.DeleteUser(u))
+	}
+
 	// Create user
-	u, err := models.NewUser("", "test@example.com", "password", config.JWT.Aud, nil)
+	u, err = models.NewUser("", "test@example.com", "password", config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error creating test user model")
 	require.NoError(ts.T(), api.db.CreateUser(u), "Error saving new test user")
 }


### PR DESCRIPTION
**- Summary**

It may be useful to a client or UI to know how a user signed up. This adds `provider` to the `app_metadata` for a user.

**- Test plan**

Added some additional asserts for provider value.

**- Description for the changelog**

Add signup provider to app_metadata.

