### PR TITLE
Use sub instead of id for user ID claim in JWT

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -36,10 +36,10 @@ func getUser(ctx context.Context, conn storage.Connection) (*models.User, error)
 		return nil, errors.New("Invalid token")
 	}
 
-	if claims.ID == "" {
+	if claims.Subject == "" {
 		return nil, errors.New("Invalid claim: id")
 	}
-	return conn.FindUserByID(claims.ID)
+	return conn.FindUserByID(claims.Subject)
 }
 
 func (api *API) isAdmin(ctx context.Context, u *models.User, aud string) bool {

--- a/api/logout.go
+++ b/api/logout.go
@@ -8,11 +8,11 @@ import (
 func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	claims := getClaims(ctx)
-	if claims == nil || claims.ID == "" {
+	if claims == nil || claims.Subject == "" {
 		return badRequestError("Could not read User ID claim")
 	}
 
-	a.db.Logout(claims.ID)
+	a.db.Logout(claims.Subject)
 	w.WriteHeader(http.StatusNoContent)
 	return nil
 }

--- a/api/token.go
+++ b/api/token.go
@@ -11,7 +11,6 @@ import (
 
 type GoTrueClaims struct {
 	jwt.StandardClaims
-	ID           string                 `json:"id"`
 	Email        string                 `json:"email"`
 	AppMetaData  map[string]interface{} `json:"app_metadata"`
 	UserMetaData map[string]interface{} `json:"user_metadata"`
@@ -153,10 +152,10 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 func generateAccessToken(user *models.User, expiresIn time.Duration, secret string) (string, error) {
 	claims := &GoTrueClaims{
 		StandardClaims: jwt.StandardClaims{
+			Subject:   user.ID,
 			Audience:  user.Aud,
 			ExpiresAt: time.Now().Add(expiresIn).Unix(),
 		},
-		ID:           user.ID,
 		Email:        user.Email,
 		AppMetaData:  user.AppMetaData,
 		UserMetaData: user.UserMetaData,

--- a/api/user.go
+++ b/api/user.go
@@ -24,7 +24,7 @@ func (a *API) UserGet(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Could not read claims")
 	}
 
-	if claims.ID == "" {
+	if claims.Subject == "" {
 		return badRequestError("Could not read User ID claim")
 	}
 
@@ -33,7 +33,7 @@ func (a *API) UserGet(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Token audience doesn't match request audience")
 	}
 
-	user, err := a.db.FindUserByID(claims.ID)
+	user, err := a.db.FindUserByID(claims.Subject)
 	if err != nil {
 		if models.IsNotFoundError(err) {
 			return notFoundError(err.Error())
@@ -57,11 +57,11 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	claims := getClaims(ctx)
-	if claims.ID == "" {
+	if claims.Subject == "" {
 		return badRequestError("Could not read User ID claim")
 	}
 
-	user, err := a.db.FindUserByID(claims.ID)
+	user, err := a.db.FindUserByID(claims.Subject)
 	if err != nil {
 		if models.IsNotFoundError(err) {
 			return notFoundError(err.Error())


### PR DESCRIPTION
**- Summary**

`sub` is the standard claim for a unique identifer. We should be using that instead of a custom `id` claim.

**- Test plan**

Tests pass.

**- Description for the changelog**

Use `sub` instead of `id` for user ID claim.
