### PR TITLE
Make time fields on user that can be empty pointers

### DIFF
--- a/api/invite.go
+++ b/api/invite.go
@@ -58,7 +58,7 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 		return unprocessableEntityError("Unable to validate email address: " + err.Error())
 	}
 
-	if user.ConfirmationSentAt.Add(config.Mailer.MaxFrequency).Before(time.Now()) {
+	if user.ConfirmationSentAt != nil && user.ConfirmationSentAt.Add(config.Mailer.MaxFrequency).Before(time.Now()) {
 		if err := mailer.InviteMail(user); err != nil {
 			return internalServerError("Error sending confirmation mail").WithInternalError(err)
 		}

--- a/api/invite.go
+++ b/api/invite.go
@@ -59,10 +59,8 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 		return unprocessableEntityError("Unable to validate email address: " + err.Error())
 	}
 
-	if user.ConfirmationSentAt != nil && user.ConfirmationSentAt.Add(config.Mailer.MaxFrequency).Before(time.Now()) {
-		if err := mailer.InviteMail(user); err != nil {
-			return internalServerError("Error sending confirmation mail").WithInternalError(err)
-		}
+	if err := mailer.InviteMail(user); err != nil {
+		return internalServerError("Error sending confirmation mail").WithInternalError(err)
 	}
 
 	user.SetRole(config.JWT.DefaultGroupName)

--- a/api/invite.go
+++ b/api/invite.go
@@ -51,7 +51,8 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return err
 	}
-	user.InvitedAt = time.Now()
+	now := time.Now()
+	user.InvitedAt = &now
 
 	mailer := getMailer(ctx)
 	if err = mailer.ValidateEmail(params.Email); err != nil {

--- a/api/invite_test.go
+++ b/api/invite_test.go
@@ -70,7 +70,8 @@ func (ts *InviteTestSuite) TestInvite() {
 
 func (ts *InviteTestSuite) TestVerifyInvite() {
 	user, err := models.NewUser("", "test@example.com", "", ts.Config.JWT.Aud, nil)
-	user.InvitedAt = time.Now()
+	now := time.Now()
+	user.InvitedAt = &now
 	user.EncryptedPassword = ""
 	require.NoError(ts.T(), err)
 	require.NoError(ts.T(), ts.API.db.CreateUser(user))
@@ -101,7 +102,8 @@ func (ts *InviteTestSuite) TestVerifyInvite() {
 
 func (ts *InviteTestSuite) TestVerifyInvite_NoPassword() {
 	user, err := models.NewUser("", "test@example.com", "", ts.Config.JWT.Aud, nil)
-	user.InvitedAt = time.Now()
+	now := time.Now()
+	user.InvitedAt = &now
 	user.EncryptedPassword = ""
 	require.NoError(ts.T(), err)
 	require.NoError(ts.T(), ts.API.db.CreateUser(user))

--- a/api/recover.go
+++ b/api/recover.go
@@ -38,7 +38,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		return internalServerError("Database error finding user").WithInternalError(err)
 	}
 
-	if user.RecoverySentAt.Add(config.Mailer.MaxFrequency).Before(time.Now()) {
+	if user.RecoverySentAt == nil || user.RecoverySentAt.Add(config.Mailer.MaxFrequency).Before(time.Now()) {
 		user.GenerateRecoveryToken()
 		if err := a.db.UpdateUser(user); err != nil {
 			return internalServerError("Database error updating user").WithInternalError(err)

--- a/api/recover_test.go
+++ b/api/recover_test.go
@@ -59,7 +59,7 @@ func TestRecover(t *testing.T) {
 func (ts *RecoverTestSuite) TestRecover_FirstRecovery() {
 	u, err := ts.API.db.FindUserByEmailAndAudience("", "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
-	u.RecoverySentAt = time.Time{}
+	u.RecoverySentAt = &time.Time{}
 	require.NoError(ts.T(), ts.API.db.UpdateUser(u))
 
 	// Request body
@@ -80,14 +80,14 @@ func (ts *RecoverTestSuite) TestRecover_FirstRecovery() {
 	u, err = ts.API.db.FindUserByEmailAndAudience("", "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 
-	assert.WithinDuration(ts.T(), time.Now(), u.RecoverySentAt, 1*time.Second)
+	assert.WithinDuration(ts.T(), time.Now(), *u.RecoverySentAt, 1*time.Second)
 }
 
 func (ts *RecoverTestSuite) TestRecover_NoEmailSent() {
 	recoveryTime := time.Now().UTC().Add(-5 * time.Minute)
 	u, err := ts.API.db.FindUserByEmailAndAudience("", "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
-	u.RecoverySentAt = recoveryTime
+	u.RecoverySentAt = &recoveryTime
 	require.NoError(ts.T(), ts.API.db.UpdateUser(u))
 
 	// Request body
@@ -109,14 +109,14 @@ func (ts *RecoverTestSuite) TestRecover_NoEmailSent() {
 	require.NoError(ts.T(), err)
 
 	// ensure it did not send a new email
-	assert.Equal(ts.T(), recoveryTime, u.RecoverySentAt)
+	assert.Equal(ts.T(), recoveryTime, *u.RecoverySentAt)
 }
 
 func (ts *RecoverTestSuite) TestRecover_NewEmailSent() {
 	recoveryTime := time.Now().UTC().Add(-20 * time.Minute)
 	u, err := ts.API.db.FindUserByEmailAndAudience("", "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
-	u.RecoverySentAt = recoveryTime
+	u.RecoverySentAt = &recoveryTime
 	require.NoError(ts.T(), ts.API.db.UpdateUser(u))
 
 	// Request body
@@ -138,5 +138,5 @@ func (ts *RecoverTestSuite) TestRecover_NewEmailSent() {
 	require.NoError(ts.T(), err)
 
 	// ensure it sent a new email
-	assert.WithinDuration(ts.T(), time.Now(), u.RecoverySentAt, 1*time.Second)
+	assert.WithinDuration(ts.T(), time.Now(), *u.RecoverySentAt, 1*time.Second)
 }

--- a/api/signup.go
+++ b/api/signup.go
@@ -65,7 +65,8 @@ func (a *API) signupExternalProvider(ctx context.Context, w http.ResponseWriter,
 		if err := mailer.ConfirmationMail(user); err != nil {
 			return internalServerError("Error sending confirmation mail").WithInternalError(err)
 		}
-		user.ConfirmationSentAt = time.Now()
+		now := time.Now()
+		user.ConfirmationSentAt = &now
 	}
 
 	if err := a.db.UpdateUser(user); err != nil {
@@ -129,7 +130,8 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 		if err := mailer.ConfirmationMail(user); err != nil {
 			return internalServerError("Error sending confirmation mail").WithInternalError(err)
 		}
-		user.ConfirmationSentAt = time.Now()
+		now := time.Now()
+		user.ConfirmationSentAt = &now
 	}
 
 	if err = a.db.UpdateUser(user); err != nil {

--- a/api/token.go
+++ b/api/token.go
@@ -65,7 +65,8 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 		return oauthError("invalid_grant", "Invalid Password")
 	}
 
-	user.LastSignInAt = time.Now()
+	now := time.Now()
+	user.LastSignInAt = &now
 	return a.issueRefreshToken(ctx, user, w)
 }
 
@@ -106,7 +107,8 @@ func (a *API) AuthorizationCodeGrant(ctx context.Context, w http.ResponseWriter,
 		return oauthError("invalid_grant", "Email not confirmed")
 	}
 
-	user.LastSignInAt = time.Now()
+	now := time.Now()
+	user.LastSignInAt = &now
 	return a.issueRefreshToken(ctx, user, w)
 }
 

--- a/api/verify.go
+++ b/api/verify.go
@@ -62,7 +62,7 @@ func (a *API) signupVerify(params *VerifyParams) (*models.User, error) {
 	}
 
 	if user.EncryptedPassword == "" {
-		if !user.InvitedAt.IsZero() {
+		if user.InvitedAt != nil {
 			if params.Password == "" {
 				return nil, unprocessableEntityError("Invited users must specify a password")
 			}

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -97,6 +97,10 @@ func (m TemplateMailer) ValidateEmail(email string) error {
 
 // InviteMail sends a invite mail to a new user
 func (m *TemplateMailer) InviteMail(user *models.User) error {
+	if user.ConfirmationSentAt != nil && !user.ConfirmationSentAt.Add(m.Config.Mailer.MaxFrequency).Before(time.Now()) {
+		return nil
+	}
+
 	url, err := getSiteURL(m.Config.SiteURL, m.Config.Mailer.MemberFolder, "/invite/"+user.ConfirmationToken)
 	if err != nil {
 		return err
@@ -120,7 +124,7 @@ func (m *TemplateMailer) InviteMail(user *models.User) error {
 
 // ConfirmationMail sends a signup confirmation mail to a new user
 func (m *TemplateMailer) ConfirmationMail(user *models.User) error {
-	if !user.ConfirmationSentAt.Add(m.Config.Mailer.MaxFrequency).Before(time.Now()) {
+	if user.ConfirmationSentAt != nil && !user.ConfirmationSentAt.Add(m.Config.Mailer.MaxFrequency).Before(time.Now()) {
 		return nil
 	}
 

--- a/models/user.go
+++ b/models/user.go
@@ -15,18 +15,18 @@ type User struct {
 	InstanceID string `json:"-" bson:"instance_id"`
 	ID         string `json:"id" bson:"_id,omitempty"`
 
-	Aud               string    `json:"aud" bson:"aud"`
-	Role              string    `json:"role" bson:"role"`
-	Email             string    `json:"email" bson:"email"`
-	EncryptedPassword string    `json:"-" bson:"encrypted_password"`
-	ConfirmedAt       time.Time `json:"confirmed_at" bson:"confirmed_at"`
-	InvitedAt         time.Time `json:"invited_at" bson:"invited_at"`
+	Aud               string     `json:"aud" bson:"aud"`
+	Role              string     `json:"role" bson:"role"`
+	Email             string     `json:"email" bson:"email"`
+	EncryptedPassword string     `json:"-" bson:"encrypted_password"`
+	ConfirmedAt       *time.Time `json:"confirmed_at" bson:"confirmed_at"`
+	InvitedAt         *time.Time `json:"invited_at" bson:"invited_at"`
 
 	ConfirmationToken  string     `json:"-" bson:"confirmation_token,omitempty"`
 	ConfirmationSentAt *time.Time `json:"confirmation_sent_at,omitempty" bson:"confirmation_sent_at,omitempty"`
 
-	RecoveryToken  string    `json:"-" bson:"recovery_token,omitempty"`
-	RecoverySentAt time.Time `json:"recovery_sent_at,omitempty" bson:"recovery_sent_at,omitempty"`
+	RecoveryToken  string     `json:"-" bson:"recovery_token,omitempty"`
+	RecoverySentAt *time.Time `json:"recovery_sent_at,omitempty" bson:"recovery_sent_at,omitempty"`
 
 	EmailChangeToken  string     `json:"-" bson:"email_change_token,omitempty"`
 	EmailChange       string     `json:"new_email,omitempty" bson:"new_email,omitempty"`
@@ -127,8 +127,9 @@ func (u *User) GenerateConfirmationToken() {
 // GenerateRecoveryToken generates a secure password recovery token
 func (u *User) GenerateRecoveryToken() {
 	token := crypto.SecureToken()
+	now := time.Now()
 	u.RecoveryToken = token
-	u.RecoverySentAt = time.Now()
+	u.RecoverySentAt = &now
 }
 
 // GenerateEmailChange prepares for verifying a new email
@@ -143,7 +144,8 @@ func (u *User) GenerateEmailChange(email string) {
 // Confirm resets the confimation token and the confirm timestamp
 func (u *User) Confirm() {
 	u.ConfirmationToken = ""
-	u.ConfirmedAt = time.Now()
+	now := time.Now()
+	u.ConfirmedAt = &now
 }
 
 // ConfirmEmailChange confirm the change of email for a user

--- a/models/user.go
+++ b/models/user.go
@@ -22,17 +22,17 @@ type User struct {
 	ConfirmedAt       time.Time `json:"confirmed_at" bson:"confirmed_at"`
 	InvitedAt         time.Time `json:"invited_at" bson:"invited_at"`
 
-	ConfirmationToken  string    `json:"-" bson:"confirmation_token,omitempty"`
-	ConfirmationSentAt time.Time `json:"confirmation_sent_at,omitempty" bson:"confirmation_sent_at,omitempty"`
+	ConfirmationToken  string     `json:"-" bson:"confirmation_token,omitempty"`
+	ConfirmationSentAt *time.Time `json:"confirmation_sent_at,omitempty" bson:"confirmation_sent_at,omitempty"`
 
 	RecoveryToken  string    `json:"-" bson:"recovery_token,omitempty"`
 	RecoverySentAt time.Time `json:"recovery_sent_at,omitempty" bson:"recovery_sent_at,omitempty"`
 
-	EmailChangeToken  string    `json:"-" bson:"email_change_token,omitempty"`
-	EmailChange       string    `json:"new_email,omitempty" bson:"new_email,omitempty"`
-	EmailChangeSentAt time.Time `json:"email_change_sent_at,omitempty" bson:"email_change_sent_at,omitempty"`
+	EmailChangeToken  string     `json:"-" bson:"email_change_token,omitempty"`
+	EmailChange       string     `json:"new_email,omitempty" bson:"new_email,omitempty"`
+	EmailChangeSentAt *time.Time `json:"email_change_sent_at,omitempty" bson:"email_change_sent_at,omitempty"`
 
-	LastSignInAt time.Time `json:"last_sign_in_at,omitempty" bson:"last_sign_in_at,omitempty"`
+	LastSignInAt *time.Time `json:"last_sign_in_at,omitempty" bson:"last_sign_in_at,omitempty"`
 
 	AppMetaData  map[string]interface{} `json:"app_metadata,omitempty" sql:"-" bson:"app_metadata,omitempty"`
 	UserMetaData map[string]interface{} `json:"user_metadata,omitempty" sql:"-" bson:"user_metadata,omitempty"`
@@ -134,8 +134,9 @@ func (u *User) GenerateRecoveryToken() {
 // GenerateEmailChange prepares for verifying a new email
 func (u *User) GenerateEmailChange(email string) {
 	token := crypto.SecureToken()
+	now := time.Now()
 	u.EmailChangeToken = token
-	u.EmailChangeSentAt = time.Now()
+	u.EmailChangeSentAt = &now
 	u.EmailChange = email
 }
 


### PR DESCRIPTION
MySQL seems to have difficulties handling Go's empty value for time fields, this
makes all time fields on a user that are optionally present pointers to work around
that.

I'm a bit afraid this could introduce panics in places where we're comparing those times without making sure they are nil first. Found one instance of this and fixed. It does seem cleaner to have the times be NULL than a "zero date" however...