### PR TITLE
Change user metadata name to full_name.

### DIFF
--- a/api/external_test.go
+++ b/api/external_test.go
@@ -214,7 +214,7 @@ func (ts *ExternalTestSuite) TestSignupExternalGitlab_AuthorizationCode() {
 	// ensure user has been created with metadata
 	user, err := ts.API.db.FindUserByEmailAndAudience("", "gitlab@example.com", ts.Config.JWT.Aud)
 	ts.Require().NoError(err)
-	ts.Equal("Gitlab Test", user.UserMetaData["name"])
+	ts.Equal("Gitlab Test", user.UserMetaData["full_name"])
 	ts.Equal("http://example.com/avatar", user.UserMetaData["avatar_url"])
 }
 

--- a/api/provider/provider.go
+++ b/api/provider/provider.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	avatarURLKey = "avatar_url"
-	nameKey      = "name"
+	nameKey      = "full_name"
 )
 
 type UserProvidedData struct {


### PR DESCRIPTION
So we are compatible with other places where it's called full_name.

Signed-off-by: David Calavera <david.calavera@gmail.com>