### PR TITLE
Ensure we always serialize user metadata.

### DIFF
--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -214,6 +214,8 @@ func (ts *AdminTestSuite) TestAdminUserGet() {
 	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
 
 	assert.Equal(ts.T(), data["email"], "test1@example.com")
+	assert.NotNil(ts.T(), data["app_metadata"])
+	assert.NotNil(ts.T(), data["user_metadata"])
 }
 
 // TestAdminUserUpdate tests API /admin/user route (UPDATE)

--- a/models/user.go
+++ b/models/user.go
@@ -34,8 +34,8 @@ type User struct {
 
 	LastSignInAt *time.Time `json:"last_sign_in_at,omitempty"`
 
-	AppMetaData  map[string]interface{} `json:"app_metadata,omitempty" sql:"-"`
-	UserMetaData map[string]interface{} `json:"user_metadata,omitempty" sql:"-"`
+	AppMetaData  map[string]interface{} `json:"app_metadata" sql:"-"`
+	UserMetaData map[string]interface{} `json:"user_metadata" sql:"-"`
 
 	IsSuperAdmin bool `json:"-"`
 
@@ -85,7 +85,11 @@ func (u *User) UpdateUserMetaData(updates map[string]interface{}) {
 		u.UserMetaData = updates
 	} else if updates != nil {
 		for key, value := range updates {
-			u.UserMetaData[key] = value
+			if value != nil {
+				u.UserMetaData[key] = value
+			} else {
+				delete(u.UserMetaData, key)
+			}
 		}
 	}
 }
@@ -96,7 +100,11 @@ func (u *User) UpdateAppMetaData(updates map[string]interface{}) {
 		u.AppMetaData = updates
 	} else if updates != nil {
 		for key, value := range updates {
-			u.AppMetaData[key] = value
+			if value != nil {
+				u.AppMetaData[key] = value
+			} else {
+				delete(u.AppMetaData, key)
+			}
 		}
 	}
 }

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -1,0 +1,43 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateAppMetadata(t *testing.T) {
+	u := &User{}
+	u.UpdateAppMetaData(make(map[string]interface{}))
+
+	require.NotNil(t, u.AppMetaData)
+
+	u.UpdateAppMetaData(map[string]interface{}{
+		"foo": "bar",
+	})
+
+	require.Equal(t, "bar", u.AppMetaData["foo"])
+	u.UpdateAppMetaData(map[string]interface{}{
+		"foo": nil,
+	})
+	require.Len(t, u.AppMetaData, 0)
+	require.Equal(t, nil, u.AppMetaData["foo"])
+}
+
+func TestUpdateUserMetadata(t *testing.T) {
+	u := &User{}
+	u.UpdateUserMetaData(make(map[string]interface{}))
+
+	require.NotNil(t, u.UserMetaData)
+
+	u.UpdateUserMetaData(map[string]interface{}{
+		"foo": "bar",
+	})
+
+	require.Equal(t, "bar", u.UserMetaData["foo"])
+	u.UpdateUserMetaData(map[string]interface{}{
+		"foo": nil,
+	})
+	require.Len(t, u.UserMetaData, 0)
+	require.Equal(t, nil, u.UserMetaData["foo"])
+}

--- a/storage/sql/user.go
+++ b/storage/sql/user.go
@@ -21,10 +21,14 @@ func (u *userObj) BeforeCreate(tx *gorm.DB) error {
 func (u *userObj) AfterFind() (err error) {
 	if u.RawAppMetaData != "" {
 		err = json.Unmarshal([]byte(u.RawAppMetaData), &u.AppMetaData)
+	} else {
+		u.AppMetaData = make(map[string]interface{})
 	}
 
 	if err == nil && u.RawUserMetaData != "" {
 		err = json.Unmarshal([]byte(u.RawUserMetaData), &u.UserMetaData)
+	} else {
+		u.UserMetaData = make(map[string]interface{})
 	}
 
 	return err


### PR DESCRIPTION
This makes it easier to integrate because clients don't need
to check if the key exists or not and whether the value is nil or not.o

Signed-off-by: David Calavera <david.calavera@gmail.com>