### PR TITLE
Allow to set SMTP credentials per tenant.

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -77,8 +77,9 @@ type SMTPConfiguration struct {
 
 // Configuration holds all the per-instance configuration.
 type Configuration struct {
-	SiteURL string           `json:"site_url" split_words:"true" required:"true"`
-	JWT     JWTConfiguration `json:"jwt"`
+	SiteURL string            `json:"site_url" split_words:"true" required:"true"`
+	JWT     JWTConfiguration  `json:"jwt"`
+	SMTP    SMTPConfiguration `json:"smtp"`
 	Mailer  struct {
 		Autoconfirm bool                      `json:"autoconfirm"`
 		Subjects    EmailContentConfiguration `json:"subjects"`

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -64,16 +64,37 @@ func NewMailer(smtp conf.SMTPConfiguration, instanceConfig *conf.Configuration) 
 		return &noopMailer{}
 	}
 
+	smtpHost := instanceConfig.SMTP.Host
+	if smtpHost == "" {
+		smtpHost = smtp.Host
+	}
+	smtpPort := instanceConfig.SMTP.Port
+	if smtpPort == 0 {
+		smtpPort = smtp.Port
+	}
+	smtpUser := instanceConfig.SMTP.User
+	if smtpUser == "" {
+		smtpUser = smtp.User
+	}
+	smtpPass := instanceConfig.SMTP.Pass
+	if smtpPass == "" {
+		smtpPass = smtp.Pass
+	}
+	smtpAdminEmail := instanceConfig.SMTP.AdminEmail
+	if smtpAdminEmail == "" {
+		smtpAdminEmail = smtp.AdminEmail
+	}
+
 	return &TemplateMailer{
 		SiteURL:      instanceConfig.SiteURL,
 		MaxFrequency: smtp.MaxFrequency,
 		Config:       instanceConfig,
 		TemplateMailer: &mailme.Mailer{
-			Host:    smtp.Host,
-			Port:    smtp.Port,
-			User:    smtp.User,
-			Pass:    smtp.Pass,
-			From:    smtp.AdminEmail,
+			Host:    smtpHost,
+			Port:    smtpPort,
+			User:    smtpUser,
+			Pass:    smtpPass,
+			From:    smtpAdminEmail,
 			BaseURL: instanceConfig.SiteURL,
 		},
 	}


### PR DESCRIPTION
Put them in a different struct at the same level than Mailer.

Signed-off-by: David Calavera <david.calavera@gmail.com>