### PR TITLE
Remove email host validation.

### DIFF
--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -107,15 +107,7 @@ func NewMailer(smtp conf.SMTPConfiguration, instanceConfig *conf.Configuration) 
 // ValidateEmail returns nil if the email is valid,
 // otherwise an error indicating the reason it is invalid
 func (m TemplateMailer) ValidateEmail(email string) error {
-	if err := checkmail.ValidateFormat(email); err != nil {
-		return err
-	}
-
-	if err := checkmail.ValidateHost(email); err != nil {
-		return err
-	}
-
-	return nil
+	return checkmail.ValidateFormat(email)
 }
 
 // InviteMail sends a invite mail to a new user


### PR DESCRIPTION
This validation tries to connect via SMTP to a host which might be very
unreliable.

Signed-off-by: David Calavera <david.calavera@gmail.com>