### PR TITLE
Fallback to the user's email when Gitlab doesn't have emails.

### DIFF
--- a/api/external.go
+++ b/api/external.go
@@ -90,7 +90,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 
 	tok, err := provider.GetOAuthToken(ctx, oauthCode)
 	if err != nil {
-		return internalServerError("Unable to exchange external code")
+		return internalServerError("Unable to exchange external code").WithInternalError(err)
 	}
 
 	aud := a.requestAud(ctx, r)

--- a/api/provider/github.go
+++ b/api/provider/github.go
@@ -22,6 +22,7 @@ type githubProvider struct {
 }
 
 type githubUser struct {
+	Email     string `json:"email"`
 	Name      string `json:"name"`
 	AvatarURL string `json:"avatar_url"`
 }

--- a/api/provider/gitlab.go
+++ b/api/provider/gitlab.go
@@ -76,7 +76,11 @@ func (g gitlabProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 	}
 
 	if data.Email == "" {
-		return nil, errors.New("Unable to find email with GitLab provider")
+		if u.Email != "" {
+			data.Email = u.Email
+		} else {
+			return nil, errors.New("Unable to find email with GitLab provider")
+		}
 	}
 
 	return data, nil


### PR DESCRIPTION
Because they don't enforce having verified emails.

Signed-off-by: David Calavera <david.calavera@gmail.com>