### PR TITLE
Ensure last sign in time is updated whenever a token is issued

### DIFF
--- a/api/external.go
+++ b/api/external.go
@@ -147,8 +147,6 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 		user.Confirm()
 	}
 
-	now := time.Now()
-	user.LastSignInAt = &now
 	token, err := a.issueRefreshToken(ctx, user)
 	if err != nil {
 		return oauthError("server_error", err.Error())

--- a/api/token.go
+++ b/api/token.go
@@ -62,8 +62,6 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 		return oauthError("invalid_grant", "Invalid Password")
 	}
 
-	now := time.Now()
-	user.LastSignInAt = &now
 	return a.sendRefreshToken(ctx, user, w)
 }
 
@@ -125,6 +123,10 @@ func generateAccessToken(user *models.User, expiresIn time.Duration, secret stri
 
 func (a *API) issueRefreshToken(ctx context.Context, user *models.User) (*AccessTokenResponse, error) {
 	config := a.getConfig(ctx)
+
+	now := time.Now()
+	user.LastSignInAt = &now
+
 	refreshToken, err := a.db.GrantAuthenticatedUser(user)
 	if err != nil {
 		return nil, internalServerError("Database error granting user").WithInternalError(err)


### PR DESCRIPTION
**- Summary**
Redeeming confirmation and recovery tokens would not have updated the last sign in time.

**- Test plan**
Existing tests pass.

**- Description for the changelog**
Update last sign in time whenever issuing tokens.
