### PR TITLE
Remove request log from the Health endpoint.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -70,7 +70,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 		if globalConfig.MultiInstanceMode {
 			r.Use(api.loadInstanceConfig)
 		}
-		r.Get("/callback", api.ExternalProviderCallback)
+		r.Get("/", api.ExternalProviderCallback)
 	})
 
 	r.Route("/", func(r *router) {

--- a/api/router.go
+++ b/api/router.go
@@ -39,6 +39,11 @@ func (r *router) With(fn middlewareHandler) *router {
 	return &router{c}
 }
 
+func (r *router) WithBypass(fn func(next http.Handler) http.Handler) *router {
+	c := r.chi.With(fn)
+	return &router{c}
+}
+
 func (r *router) Use(fn middlewareHandler) {
 	r.chi.Use(middleware(fn))
 }


### PR DESCRIPTION
This log is very noisy and it doesn't provide much value.

Signed-off-by: David Calavera <david.calavera@gmail.com>