### PR TITLE
Add support for a system user

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -42,9 +42,9 @@ func getUserFromClaims(ctx context.Context, conn storage.Connection) (*models.Us
 
 	if claims.Subject == models.SystemUserID {
 		// System User
-		instance := getInstance(ctx)
+		instanceID := getInstanceID(ctx)
 
-		return models.NewSystemUser(instance.ID, claims.Audience), nil
+		return models.NewSystemUser(instanceID, claims.Audience), nil
 	}
 	return conn.FindUserByID(claims.Subject)
 }

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -39,6 +39,13 @@ func getUserFromClaims(ctx context.Context, conn storage.Connection) (*models.Us
 	if claims.Subject == "" {
 		return nil, errors.New("Invalid claim: id")
 	}
+
+	if claims.Subject == models.SystemUserID {
+		// System User
+		instance := getInstance(ctx)
+
+		return models.NewSystemUser(instance.ID, claims.Audience), nil
+	}
 	return conn.FindUserByID(claims.Subject)
 }
 


### PR DESCRIPTION
This introduces the concept of a "System User" with ID "0" that is not an actual user in the system, but can act as a super admin in terms of updating app_metadata and managing users.

This allow us to issue management API tokens when we know the JWT secret.
This in turns will let us give management API access to cloud functions, and similar applications that needs to update user app metadata without acting directly on behalf of some specific admin user in the system.

There's no way to get a system user JWT issued by gotrue (by design). You'll need to know the JWT secret to create system user tokens.

