### PR TITLE
Set cookie with JWT when requested

### DIFF
--- a/api/logout.go
+++ b/api/logout.go
@@ -14,5 +14,8 @@ func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 
 	a.db.Logout(claims.Subject)
 	w.WriteHeader(http.StatusNoContent)
+
+	a.clearCookieToken(ctx, w)
+
 	return nil
 }

--- a/api/token.go
+++ b/api/token.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
+	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
 )
 
@@ -69,7 +70,7 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 	}
 
 	if cookie != "" && config.Cookie.Enabled {
-		if err = a.setCookieToken(ctx, user, cookie == useSessionCookie, w); err != nil {
+		if err = a.setCookieToken(config, user, cookie == useSessionCookie, w); err != nil {
 			return internalServerError("Failed to set JWT cookie", err)
 		}
 	}
@@ -111,7 +112,7 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 	}
 
 	if cookie != "" && config.Cookie.Enabled {
-		if err = a.setCookieToken(ctx, user, cookie == useSessionCookie, w); err != nil {
+		if err = a.setCookieToken(config, user, cookie == useSessionCookie, w); err != nil {
 			return internalServerError("Failed to set JWT cookie", err)
 		}
 	}
@@ -165,8 +166,7 @@ func (a *API) issueRefreshToken(ctx context.Context, user *models.User) (*Access
 	}, nil
 }
 
-func (a *API) setCookieToken(ctx context.Context, user *models.User, session bool, w http.ResponseWriter) error {
-	config := getConfig(ctx)
+func (a *API) setCookieToken(config *conf.Configuration, user *models.User, session bool, w http.ResponseWriter) error {
 	exp := time.Second * time.Duration(config.Cookie.Duration)
 
 	tokenString, err := generateAccessToken(user, exp, config.JWT.Secret)

--- a/api/token.go
+++ b/api/token.go
@@ -69,7 +69,9 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 	}
 
 	if cookie != "" && config.Cookie.Enabled {
-		a.setCookieToken(ctx, user, cookie == useSessionCookie, w)
+		if err = a.setCookieToken(ctx, user, cookie == useSessionCookie, w); err != nil {
+			return internalServerError("Failed to set JWT cookie", err)
+		}
 	}
 
 	return a.sendRefreshToken(ctx, user, w)
@@ -109,7 +111,9 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 	}
 
 	if cookie != "" && config.Cookie.Enabled {
-		a.setCookieToken(ctx, user, cookie == useSessionCookie, w)
+		if err = a.setCookieToken(ctx, user, cookie == useSessionCookie, w); err != nil {
+			return internalServerError("Failed to set JWT cookie", err)
+		}
 	}
 
 	return sendJSON(w, http.StatusOK, &AccessTokenResponse{

--- a/api/verify.go
+++ b/api/verify.go
@@ -23,6 +23,7 @@ type VerifyParams struct {
 func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	params := &VerifyParams{}
+	cookie := r.Header.Get(useCookieHeader)
 	jsonDecoder := json.NewDecoder(r.Body)
 	if err := jsonDecoder.Decode(params); err != nil {
 		return badRequestError("Could not read verification params: %v", err)
@@ -49,6 +50,11 @@ func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return err
 	}
+
+	if cookie != "" {
+		a.setCookieToken(ctx, user, cookie == useSessionCookie, w)
+	}
+
 	return a.sendRefreshToken(ctx, user, w)
 }
 

--- a/api/verify.go
+++ b/api/verify.go
@@ -54,7 +54,7 @@ func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if cookie != "" && config.Cookie.Enabled {
-		if err = a.setCookieToken(ctx, user, cookie == useSessionCookie, w); err != nil {
+		if err = a.setCookieToken(config, user, cookie == useSessionCookie, w); err != nil {
 			return internalServerError("Failed to set JWT cookie", err)
 		}
 	}

--- a/api/verify.go
+++ b/api/verify.go
@@ -54,7 +54,9 @@ func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if cookie != "" && config.Cookie.Enabled {
-		a.setCookieToken(ctx, user, cookie == useSessionCookie, w)
+		if err = a.setCookieToken(ctx, user, cookie == useSessionCookie, w); err != nil {
+			return internalServerError("Failed to set JWT cookie", err)
+		}
 	}
 
 	return a.sendRefreshToken(ctx, user, w)

--- a/api/verify.go
+++ b/api/verify.go
@@ -22,6 +22,8 @@ type VerifyParams struct {
 // Verify exchanges a confirmation or recovery token to a refresh token
 func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
+	config := getConfig(ctx)
+
 	params := &VerifyParams{}
 	cookie := r.Header.Get(useCookieHeader)
 	jsonDecoder := json.NewDecoder(r.Body)
@@ -51,7 +53,7 @@ func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	if cookie != "" {
+	if cookie != "" && config.Cookie.Enabled {
 		a.setCookieToken(ctx, user, cookie == useSessionCookie, w)
 	}
 

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -90,6 +90,11 @@ type Configuration struct {
 	} `json:"mailer"`
 	External      ExternalProviderConfiguration `json:"external"`
 	DisableSignup bool                          `json:"disable_signup" split_words:"true"`
+	Cookie        struct {
+		Key      string `json:"key" default:"nf_jwt"`
+		Enabled  bool   `json:"enabled" default:"true"`
+		Duration int    `json:"duration" default:"86400"`
+	} `json:"cookies"`
 }
 
 func loadEnvironment(filename string) error {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/gotrue/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Netlify allows role based authentication with JWTs and this fits great with Gotrue, but requires a lot of trickery client site to set cookies, and it also means the cookies can't follow best practices like being HTTP only.

This PR allows the consumer of GoTrue to pass a "X-Set-Cookie" header along when requesting a token. If GoTrue has been configured to allow cookies, it will then set a cookie with a JWT in the response. This should make it much more straight forward to take advantage of Netlify's CDN based access control for static files.

**- Test plan**

It's easy to verify whether we set the cookie or not, but the real test will be to integrate this with a site using Netlify's role based access control.

**- Description for the changelog**

Support for setting a secure, httpOnly cookie with a JWT on authentication.
