### PR TITLE
Sign webhooks with a configured secret

### DIFF
--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -95,7 +95,7 @@ func TestHookTimeout(t *testing.T) {
 	w := Webhook{
 		WebhookConfig: config,
 	}
-	b, err := w.trigger()
+	_, err := w.trigger()
 	require.Error(t, err)
 	herr, ok := err.(*HTTPError)
 	require.True(t, ok)
@@ -113,7 +113,7 @@ func TestHookNoServer(t *testing.T) {
 	w := Webhook{
 		WebhookConfig: config,
 	}
-	b, err := w.trigger()
+	_, err := w.trigger()
 	require.Error(t, err)
 	herr, ok := err.(*HTTPError)
 	require.True(t, ok)

--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -38,7 +38,7 @@ func TestSignupHookSendInstanceID(t *testing.T) {
 		URL: svr.URL,
 	}
 
-	require.NoError(t, triggerSignupHook(user, "myinstance", "", config))
+	require.NoError(t, triggerHook(SignupEvent, user, "myinstance", "", config))
 
 	assert.Equal(t, 1, callCount)
 }

--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -37,13 +37,8 @@ func TestSignupHookSendInstanceID(t *testing.T) {
 	config := &conf.WebhookConfig{
 		URL: svr.URL,
 	}
-	b, err := triggerSignupHook(user, "myinstance", "", config)
-	defer func() {
-		if b != nil {
-			b.Close()
-		}
-	}()
-	require.NoError(t, err)
+
+	require.NoError(t, triggerSignupHook(user, "myinstance", "", config))
 
 	assert.Equal(t, 1, callCount)
 }

--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -37,7 +37,13 @@ func TestSignupHookSendInstanceID(t *testing.T) {
 	config := &conf.WebhookConfig{
 		URL: svr.URL,
 	}
-	require.NoError(t, triggerSignupHook(user, "myinstance", "", config))
+	b, err := triggerSignupHook(user, "myinstance", "", config)
+	defer func() {
+		if b != nil {
+			b.Close()
+		}
+	}()
+	require.NoError(t, err)
 
 	assert.Equal(t, 1, callCount)
 }
@@ -62,7 +68,13 @@ func TestHookRetry(t *testing.T) {
 	w := Webhook{
 		WebhookConfig: config,
 	}
-	require.NoError(t, w.trigger())
+	b, err := w.trigger()
+	defer func() {
+		if b != nil {
+			b.Close()
+		}
+	}()
+	require.NoError(t, err)
 
 	assert.Equal(t, 3, callCount)
 }
@@ -83,7 +95,7 @@ func TestHookTimeout(t *testing.T) {
 	w := Webhook{
 		WebhookConfig: config,
 	}
-	err := w.trigger()
+	b, err := w.trigger()
 	require.Error(t, err)
 	herr, ok := err.(*HTTPError)
 	require.True(t, ok)
@@ -101,7 +113,7 @@ func TestHookNoServer(t *testing.T) {
 	w := Webhook{
 		WebhookConfig: config,
 	}
-	err := w.trigger()
+	b, err := w.trigger()
 	require.Error(t, err)
 	herr, ok := err.(*HTTPError)
 	require.True(t, ok)

--- a/api/hooks.go
+++ b/api/hooks.go
@@ -16,10 +16,15 @@ import (
 	"github.com/netlify/gotrue/models"
 )
 
+type HookEvent string
+
 const (
 	headerHookSignature = "x-gotrue-signature"
 	defaultHookRetries  = 3
 	gotrueIssuer        = "gotrue"
+	ValidateEvent       = "validate"
+	SignupEvent         = "signup"
+	LoginEvent          = "login"
 )
 
 var defaultTimeout time.Duration = time.Second * 5
@@ -135,17 +140,17 @@ func closeBody(rsp *http.Response) {
 	}
 }
 
-func triggerSignupHook(user *models.User, instanceID, jwtSecret string, hconfig *conf.WebhookConfig) error {
+func triggerHook(event HookEvent, user *models.User, instanceID, jwtSecret string, hconfig *conf.WebhookConfig) error {
 	if hconfig.URL == "" {
 		return nil
 	}
 
 	payload := struct {
-		Event      string       `json:"event"`
+		Event      HookEvent    `json:"event"`
 		InstanceID string       `json:"instance_id,omitempty"`
 		User       *models.User `json:"user"`
 	}{
-		Event:      "signup",
+		Event:      event,
 		InstanceID: instanceID,
 		User:       user,
 	}

--- a/api/signup.go
+++ b/api/signup.go
@@ -99,7 +99,7 @@ func (a *API) signupNewUser(ctx context.Context, params *SignupParams, aud strin
 
 	user.SetRole(config.JWT.DefaultGroupName)
 
-	if err := triggerSignupHook(user, instanceID, config.SignupHook.Secret, &config.SignupHook); err != nil {
+	if err := triggerHook(SignupEvent, user, instanceID, config.SignupHook.Secret, &config.SignupHook); err != nil {
 		return nil, err
 	}
 

--- a/api/signup.go
+++ b/api/signup.go
@@ -17,11 +17,6 @@ type SignupParams struct {
 	Provider string
 }
 
-type WebhookResponse struct {
-	AppMetaData  map[string]interface{} `json:"app_metadata,omitempty"`
-	UserMetaData map[string]interface{} `json:"user_metadata,omitempty"`
-}
-
 // Signup is the endpoint for registering a new user
 func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
@@ -104,23 +99,8 @@ func (a *API) signupNewUser(ctx context.Context, params *SignupParams, aud strin
 
 	user.SetRole(config.JWT.DefaultGroupName)
 
-	body, err := triggerSignupHook(user, instanceID, config.SignupHook.Secret, &config.SignupHook)
-	if err != nil {
+	if err := triggerSignupHook(user, instanceID, config.SignupHook.Secret, &config.SignupHook); err != nil {
 		return nil, err
-	}
-	if body != nil {
-		defer body.Close()
-		webhookRsp := &WebhookResponse{}
-		decoder := json.NewDecoder(body)
-		if err = decoder.Decode(webhookRsp); err != nil {
-			return nil, internalServerError("Webhook returned malformed JSON: %v", err).WithInternalError(err)
-		}
-		if webhookRsp.UserMetaData != nil {
-			user.UserMetaData = webhookRsp.UserMetaData
-		}
-		if webhookRsp.AppMetaData != nil {
-			user.AppMetaData = webhookRsp.AppMetaData
-		}
 	}
 
 	if err := a.db.CreateUser(user); err != nil {

--- a/api/signup.go
+++ b/api/signup.go
@@ -99,8 +99,10 @@ func (a *API) signupNewUser(ctx context.Context, params *SignupParams, aud strin
 
 	user.SetRole(config.JWT.DefaultGroupName)
 
-	if err := triggerHook(SignupEvent, user, instanceID, config.SignupHook.Secret, &config.SignupHook); err != nil {
-		return nil, err
+	if config.Webhook.HasEvent("validate") {
+		if err := triggerHook(ValidateEvent, user, instanceID, config.Webhook.Secret, &config.Webhook); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := a.db.CreateUser(user); err != nil {

--- a/api/signup.go
+++ b/api/signup.go
@@ -108,8 +108,8 @@ func (a *API) signupNewUser(ctx context.Context, params *SignupParams, aud strin
 	if err != nil {
 		return nil, err
 	}
-	defer body.Close()
 	if body != nil {
+		defer body.Close()
 		webhookRsp := &WebhookResponse{}
 		decoder := json.NewDecoder(body)
 		if err = decoder.Decode(webhookRsp); err != nil {

--- a/api/signup.go
+++ b/api/signup.go
@@ -99,7 +99,7 @@ func (a *API) signupNewUser(ctx context.Context, params *SignupParams, aud strin
 
 	user.SetRole(config.JWT.DefaultGroupName)
 
-	if err := triggerSignupHook(user, instanceID, config.JWT.Secret, &config.SignupHook); err != nil {
+	if err := triggerSignupHook(user, instanceID, config.SignupHook.Secret, &config.SignupHook); err != nil {
 		return nil, err
 	}
 

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -91,7 +91,7 @@ func (ts *SignupTestSuite) TestWebhookTriggered() {
 		p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
 		claims := new(jwt.StandardClaims)
 		token, err := p.ParseWithClaims(signature, claims, func(token *jwt.Token) (interface{}, error) {
-			return []byte(ts.Config.JWT.Secret), nil
+			return []byte(ts.Config.SignupHook.Secret), nil
 		})
 		assert.True(token.Valid)
 		assert.Equal("", claims.Subject) // not configured for multitenancy
@@ -141,6 +141,7 @@ func (ts *SignupTestSuite) TestWebhookTriggered() {
 		URL:        svr.URL,
 		Retries:    1,
 		TimeoutSec: 1,
+		Secret:     "top-secret",
 	}
 	var buffer bytes.Buffer
 	require.NoError(json.NewEncoder(&buffer).Encode(map[string]interface{}{

--- a/api/token.go
+++ b/api/token.go
@@ -75,6 +75,13 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 		}
 	}
 
+	if config.Webhook.HasEvent("login") {
+		if err := triggerHook(LoginEvent, user, instanceID, config.Webhook.Secret, &config.Webhook); err != nil {
+			return err
+		}
+		a.db.UpdateUser(user)
+	}
+
 	return a.sendRefreshToken(ctx, user, w)
 }
 

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -91,7 +91,7 @@ type Configuration struct {
 	} `json:"mailer"`
 	External      ExternalProviderConfiguration `json:"external"`
 	DisableSignup bool                          `json:"disable_signup" split_words:"true"`
-	SignupHook    WebhookConfig                 `json:"signup_hook" split_words:"true"`
+	Webhook       WebhookConfig                 `json:"webhook" split_words:"true"`
 	Cookie        struct {
 		Key      string `json:"key"`
 		Duration int    `json:"duration"`
@@ -113,10 +113,20 @@ func loadEnvironment(filename string) error {
 }
 
 type WebhookConfig struct {
-	URL        string `json:"url"`
-	Retries    int    `json:"retries"`
-	TimeoutSec int    `json:"timeout_sec"`
-	Secret     string `json:"jwt_secret"`
+	URL        string   `json:"url"`
+	Retries    int      `json:"retries"`
+	TimeoutSec int      `json:"timeout_sec"`
+	Secret     string   `json:"jwt_secret"`
+	Events     []string `json:"events"`
+}
+
+func (w *WebhookConfig) HasEvent(event string) bool {
+	for _, name := range w.Events {
+		if event == name {
+			return true
+		}
+	}
+	return false
 }
 
 // LoadGlobal loads configuration from file and environment variables.

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -116,6 +116,7 @@ type WebhookConfig struct {
 	URL        string `json:"url"`
 	Retries    int    `json:"retries"`
 	TimeoutSec int    `json:"timeout_sec"`
+	Secret     string `json:"jwt_secret"`
 }
 
 // LoadGlobal loads configuration from file and environment variables.


### PR DESCRIPTION
we don't normally share the jwt secret for the instance with the world,
so for webhooks we need a secret we are allowed to share