### PR TITLE
Hook fixes

### DIFF
--- a/api/external.go
+++ b/api/external.go
@@ -145,7 +145,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 		}
 
 		if config.Webhook.HasEvent("signup") {
-			if err := triggerHook(SignupEvent, user, instanceID, config.Webhook.Secret, &config.Webhook); err != nil {
+			if err := triggerHook(SignupEvent, user, instanceID, config); err != nil {
 				return err
 			}
 			a.db.UpdateUser(user)
@@ -199,7 +199,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 			}
 
 			if config.Webhook.HasEvent("signup") {
-				if err := triggerHook(SignupEvent, user, instanceID, config.Webhook.Secret, &config.Webhook); err != nil {
+				if err := triggerHook(SignupEvent, user, instanceID, config); err != nil {
 					return err
 				}
 				a.db.UpdateUser(user)
@@ -209,7 +209,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 			user.Confirm()
 		} else {
 			if config.Webhook.HasEvent("login") {
-				if err := triggerHook(LoginEvent, user, instanceID, config.Webhook.Secret, &config.Webhook); err != nil {
+				if err := triggerHook(LoginEvent, user, instanceID, config); err != nil {
 					return err
 				}
 				a.db.UpdateUser(user)

--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -34,11 +34,13 @@ func TestSignupHookSendInstanceID(t *testing.T) {
 	}))
 	defer svr.Close()
 
-	config := &conf.WebhookConfig{
-		URL: svr.URL,
+	config := &conf.Configuration{
+		Webhook: conf.WebhookConfig{
+			URL: svr.URL,
+		},
 	}
 
-	require.NoError(t, triggerHook(SignupEvent, user, "myinstance", "", config))
+	require.NoError(t, triggerHook(SignupEvent, user, "myinstance", config))
 
 	assert.Equal(t, 1, callCount)
 }

--- a/api/hooks.go
+++ b/api/hooks.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/netlify/gotrue/conf"
@@ -147,13 +148,13 @@ func triggerHook(event HookEvent, user *models.User, instanceID string, config *
 	}
 	hookURL, err := url.Parse(config.Webhook.URL)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "Failed to parse Webhook URL")
 	}
 
 	if !hookURL.IsAbs() {
 		siteURL, err := url.Parse(config.SiteURL)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "Failed to parse Site URL")
 		}
 		hookURL.Scheme = siteURL.Scheme
 		hookURL.Host = siteURL.Host

--- a/api/signup.go
+++ b/api/signup.go
@@ -100,7 +100,7 @@ func (a *API) signupNewUser(ctx context.Context, params *SignupParams, aud strin
 	user.SetRole(config.JWT.DefaultGroupName)
 
 	if config.Webhook.HasEvent("validate") {
-		if err := triggerHook(ValidateEvent, user, instanceID, config.Webhook.Secret, &config.Webhook); err != nil {
+		if err := triggerHook(ValidateEvent, user, instanceID, config); err != nil {
 			return nil, err
 		}
 	}

--- a/api/token.go
+++ b/api/token.go
@@ -76,7 +76,7 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 	}
 
 	if config.Webhook.HasEvent("login") {
-		if err := triggerHook(LoginEvent, user, instanceID, config.Webhook.Secret, &config.Webhook); err != nil {
+		if err := triggerHook(LoginEvent, user, instanceID, config); err != nil {
 			return err
 		}
 		a.db.UpdateUser(user)

--- a/api/verify.go
+++ b/api/verify.go
@@ -87,7 +87,7 @@ func (a *API) signupVerify(ctx context.Context, params *VerifyParams) (*models.U
 	}
 
 	if config.Webhook.HasEvent("signup") {
-		if err := triggerHook(SignupEvent, user, instanceID, config.Webhook.Secret, &config.Webhook); err != nil {
+		if err := triggerHook(SignupEvent, user, instanceID, config); err != nil {
 			return nil, err
 		}
 		a.db.UpdateUser(user)
@@ -111,7 +111,7 @@ func (a *API) recoverVerify(ctx context.Context, params *VerifyParams) (*models.
 	user.Recover()
 	if !user.IsConfirmed() {
 		if config.Webhook.HasEvent("signup") {
-			if err := triggerHook(SignupEvent, user, instanceID, config.Webhook.Secret, &config.Webhook); err != nil {
+			if err := triggerHook(SignupEvent, user, instanceID, config); err != nil {
 				return nil, err
 			}
 			a.db.UpdateUser(user)

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -116,7 +116,7 @@ type WebhookConfig struct {
 	URL        string   `json:"url"`
 	Retries    int      `json:"retries"`
 	TimeoutSec int      `json:"timeout_sec"`
-	Secret     string   `json:"jwt_secret"`
+	Secret     string   `json:"secret"`
 	Events     []string `json:"events"`
 }
 


### PR DESCRIPTION
This makes sure that relative URLs uses the configured SiteURL as their base for webhooks.

Also changes `jwt_secret` to `secret` in webhook configuration for consistency