### PR TITLE
Trigger signup hook on auto confirm

### DIFF
--- a/api/signup.go
+++ b/api/signup.go
@@ -64,6 +64,12 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if config.Mailer.Autoconfirm {
+		if config.Webhook.HasEvent("signup") {
+			if err := triggerHook(SignupEvent, user, instanceID, config); err != nil {
+				return err
+			}
+			a.db.UpdateUser(user)
+		}
 		user.Confirm()
 	} else {
 		if err := mailer.ConfirmationMail(user); err != nil {


### PR DESCRIPTION
So far we didn't trigger the signup hook before the user confirmed the signup, and this didn't trigger when the auto confirm setting was enabled.