### PR TITLE
Redirect back to referrer when using external providers unless overridden

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -197,10 +197,6 @@ func (a *API) getConfig(ctx context.Context) *conf.Configuration {
 		return nil
 	}
 
-	if extConfig.RedirectURL == "" {
-		extConfig.RedirectURL = config.SiteURL
-	}
-
 	config.External = extConfig
 	return config
 }

--- a/api/context.go
+++ b/api/context.go
@@ -27,6 +27,7 @@ const (
 	netlifyIDKey            = contextKey("netlify_id")
 	externalProviderTypeKey = contextKey("external_provider_type")
 	userKey                 = contextKey("user")
+	externalReferrerKey     = contextKey("external_referrer")
 )
 
 // withToken adds the JWT token to the context.
@@ -187,6 +188,19 @@ func withExternalProviderType(ctx context.Context, id string) context.Context {
 // getExternalProviderType reads the request ID from the context.
 func getExternalProviderType(ctx context.Context) string {
 	obj := ctx.Value(externalProviderTypeKey)
+	if obj == nil {
+		return ""
+	}
+
+	return obj.(string)
+}
+
+func withExternalReferrer(ctx context.Context, token string) context.Context {
+	return context.WithValue(ctx, externalReferrerKey, token)
+}
+
+func getExternalReferrer(ctx context.Context) string {
+	obj := ctx.Value(externalReferrerKey)
 	if obj == nil {
 		return ""
 	}

--- a/api/external_test.go
+++ b/api/external_test.go
@@ -171,6 +171,7 @@ func (ts *ExternalTestSuite) TestSignupExternalGitlab_AuthorizationCode() {
 
 	// get redirect url w/ state
 	req := httptest.NewRequest(http.MethodGet, "http://localhost/authorize?provider=gitlab", nil)
+	req.Header.Set("Referer", "https://example.netlify.com/admin")
 	w := httptest.NewRecorder()
 	ts.API.handler.ServeHTTP(w, req)
 	ts.Require().Equal(http.StatusFound, w.Code)
@@ -192,6 +193,7 @@ func (ts *ExternalTestSuite) TestSignupExternalGitlab_AuthorizationCode() {
 	ts.Require().Equal(http.StatusFound, w.Code)
 	u, err = url.Parse(w.Header().Get("Location"))
 	ts.Require().NoError(err, "redirect url parse failed")
+	ts.Require().Equal("/admin", u.Path)
 
 	// ensure redirect has #access_token=...
 	v, err = url.ParseQuery(u.Fragment)


### PR DESCRIPTION
Fixes #102

**- Summary**

See #102

**- Test plan**

Added assertion during an external redirect test.

**- Description for the changelog**

Redirect back to referrer for external providers.