### PR TITLE
Add admin search of users via `filter` query param

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -60,7 +60,9 @@ func (a *API) adminUsers(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Bad Sort Parameters: %v", err)
 	}
 
-	users, err := a.db.FindUsersInAudience(instanceID, aud, pageParams, sortParams)
+	filter := r.URL.Query().Get("filter")
+
+	users, err := a.db.FindUsersInAudience(instanceID, aud, pageParams, sortParams, filter)
 	if err != nil {
 		return internalServerError("Database error finding users").WithInternalError(err)
 	}

--- a/migrations/20180103212743_json_user_metadata.up.sql
+++ b/migrations/20180103212743_json_user_metadata.up.sql
@@ -1,3 +1,5 @@
+ALTER TABLE `users` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
 UPDATE `users` SET `raw_app_meta_data` = '{}' WHERE `raw_app_meta_data` = '';
 UPDATE `users` SET `raw_user_meta_data` = '{}' WHERE `raw_user_meta_data` = '';
 

--- a/storage/sql/storage_test.go
+++ b/storage/sql/storage_test.go
@@ -64,7 +64,7 @@ func (s *StorageTestSuite) TestFindUserByEmailAndAudience() {
 func (s *StorageTestSuite) TestFindUsersInAudience() {
 	u := s.createUser()
 
-	n, err := s.C.FindUsersInAudience(u.InstanceID, u.Aud, nil, nil)
+	n, err := s.C.FindUsersInAudience(u.InstanceID, u.Aud, nil, nil, "")
 	require.NoError(s.T(), err)
 	require.Len(s.T(), n, 1)
 
@@ -72,7 +72,7 @@ func (s *StorageTestSuite) TestFindUsersInAudience() {
 		Page:    1,
 		PerPage: 50,
 	}
-	n, err = s.C.FindUsersInAudience(u.InstanceID, u.Aud, &p, nil)
+	n, err = s.C.FindUsersInAudience(u.InstanceID, u.Aud, &p, nil, "")
 	require.NoError(s.T(), err)
 	require.Len(s.T(), n, 1)
 	assert.Equal(s.T(), uint64(1), p.Count)
@@ -82,7 +82,7 @@ func (s *StorageTestSuite) TestFindUsersInAudience() {
 			models.SortField{Name: "created_at", Dir: models.Descending},
 		},
 	}
-	n, err = s.C.FindUsersInAudience(u.InstanceID, u.Aud, nil, sp)
+	n, err = s.C.FindUsersInAudience(u.InstanceID, u.Aud, nil, sp, "")
 	require.NoError(s.T(), err)
 	require.Len(s.T(), n, 1)
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -16,7 +16,7 @@ type Connection interface {
 	FindUserByInstanceIDAndID(instanceID, id string) (*models.User, error)
 	FindUserByRecoveryToken(token string) (*models.User, error)
 	FindUserWithRefreshToken(token string) (*models.User, *models.RefreshToken, error)
-	FindUsersInAudience(instanceID string, aud string, pageParams *models.Pagination, sortParams *models.SortParams) ([]*models.User, error)
+	FindUsersInAudience(instanceID string, aud string, pageParams *models.Pagination, sortParams *models.SortParams, filter string) ([]*models.User, error)
 	GrantAuthenticatedUser(user *models.User) (*models.RefreshToken, error)
 	GrantRefreshTokenSwap(user *models.User, token *models.RefreshToken) (*models.RefreshToken, error)
 	IsDuplicatedEmail(instanceID string, email, aud string) (bool, error)


### PR DESCRIPTION
**- Summary**

Add admin search of users via `filter` query param. This will perform a case-insensitive search on the `email` column, and the `full_name` key of the user metadata.

**- Test plan**

Added tests for both email and name.

**- Description for the changelog**

Add admin search of users via `filter` query param
