### PR TITLE
Replace gorm with pop for db access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .env
-gorm.db
 vendor/
 gotrue
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ migrate_test: ## Run database migrations for test.
 	hack/migrate.sh test
 
 test: ## Run tests.
-	go test -v $(CHECK_FILES)
+	go test -p 1 -v $(CHECK_FILES)
 
 vet: # Vet the code
 	go vet $(CHECK_FILES)

--- a/README.md
+++ b/README.md
@@ -58,19 +58,15 @@ DATABASE_URL=root@localhost/gotrue
 
 `DB_DRIVER` - `string` **required**
 
-Chooses what dialect of database you want. Choose from `mysql` or `postgres`.
+Chooses what dialect of database you want. Must be `mysql`.
 
 `DATABASE_URL` (no prefix) / `DB_DATABASE_URL` - `string` **required**
 
-Connection string for the database. See the [gorm examples](https://github.com/jinzhu/gorm/blob/gh-pages/documents/database.md) for more details.
+Connection string for the database.
 
 `DB_NAMESPACE` - `string`
 
 Adds a prefix to all table names.
-
-`DB_AUTOMIGRATE` - `bool`
-
-If enabled, creates missing tables and columns upon startup.
 
 ### Logging
 

--- a/api/admin.go
+++ b/api/admin.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/netlify/gotrue/models"
+	uuid "github.com/satori/go.uuid"
 )
 
 type adminUserParams struct {
@@ -20,7 +21,11 @@ type adminUserParams struct {
 }
 
 func (a *API) loadUser(w http.ResponseWriter, r *http.Request) (context.Context, error) {
-	userID := chi.URLParam(r, "user_id")
+	userID, err := uuid.FromString(chi.URLParam(r, "user_id"))
+	if err != nil {
+		return nil, badRequestError("user_id must be an UUID")
+	}
+
 	logEntrySetField(r, "user_id", userID)
 	instanceID := getInstanceID(r.Context())
 

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -12,7 +12,7 @@ import (
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage/test"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -25,7 +25,7 @@ type AdminTestSuite struct {
 	Config *conf.Configuration
 
 	token      string
-	instanceID string
+	instanceID uuid.UUID
 }
 
 func TestAdmin(t *testing.T) {
@@ -37,12 +37,14 @@ func TestAdmin(t *testing.T) {
 		Config:     config,
 		instanceID: instanceID,
 	}
+	defer api.db.Close()
+	//defer api.db.DropDB()
 
 	suite.Run(t, ts)
 }
 
 func (ts *AdminTestSuite) SetupTest() {
-	test.CleanupTables()
+	ts.API.db.TruncateAll()
 	ts.token = ts.makeSuperAdmin("test@example.com")
 }
 
@@ -70,7 +72,7 @@ func (ts *AdminTestSuite) makeSuperAdmin(email string) string {
 }
 
 func (ts *AdminTestSuite) makeSystemUser() string {
-	u := models.NewSystemUser("", ts.Config.JWT.Aud)
+	u := models.NewSystemUser(uuid.Nil, ts.Config.JWT.Aud)
 
 	token, err := generateAccessToken(u, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
 	require.NoError(ts.T(), err, "Error generating access token")
@@ -107,6 +109,7 @@ func (ts *AdminTestSuite) TestAdminUsers() {
 	assert.Equal(ts.T(), "</admin/users?page=1>; rel=\"last\"", w.HeaderMap.Get("Link"))
 	assert.Equal(ts.T(), "1", w.HeaderMap.Get("X-Total-Count"))
 
+	fmt.Println(w.Body)
 	data := struct {
 		Users []*models.User `json:"users"`
 		Aud   string         `json:"aud"`
@@ -153,6 +156,8 @@ func (ts *AdminTestSuite) TestAdminUsers_SortAsc() {
 	u, err := models.NewUser(ts.instanceID, "test1@example.com", "test", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error making new user")
 
+	// if the created_at times are the same, then the sort order is not guaranteed
+	time.Sleep(1 * time.Second)
 	require.NoError(ts.T(), ts.API.db.CreateUser(u), "Error creating user")
 
 	// Setup request
@@ -182,6 +187,8 @@ func (ts *AdminTestSuite) TestAdminUsers_SortAsc() {
 func (ts *AdminTestSuite) TestAdminUsers_SortDesc() {
 	u, err := models.NewUser(ts.instanceID, "test1@example.com", "test", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error making new user")
+	// if the created_at times are the same, then the sort order is not guaranteed
+	time.Sleep(1 * time.Second)
 	require.NoError(ts.T(), ts.API.db.CreateUser(u), "Error creating user")
 
 	// Setup request
@@ -279,7 +286,7 @@ func (ts *AdminTestSuite) TestAdminUserCreate() {
 
 // TestAdminUserGet tests API /admin/user route (GET)
 func (ts *AdminTestSuite) TestAdminUserGet() {
-	u, err := models.NewUser(ts.instanceID, "test1@example.com", "test", ts.Config.JWT.Aud, nil)
+	u, err := models.NewUser(ts.instanceID, "test1@example.com", "test", ts.Config.JWT.Aud, map[string]interface{}{"full_name": "Test Get User"})
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.CreateUser(u), "Error creating user")
 
@@ -298,6 +305,8 @@ func (ts *AdminTestSuite) TestAdminUserGet() {
 	assert.Equal(ts.T(), data["email"], "test1@example.com")
 	assert.NotNil(ts.T(), data["app_metadata"])
 	assert.NotNil(ts.T(), data["user_metadata"])
+	md := data["user_metadata"].(map[string]interface{})
+	assert.Equal(ts.T(), "Test Get User", md["full_name"])
 }
 
 // TestAdminUserUpdate tests API /admin/user route (UPDATE)

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -109,7 +109,6 @@ func (ts *AdminTestSuite) TestAdminUsers() {
 	assert.Equal(ts.T(), "</admin/users?page=1>; rel=\"last\"", w.HeaderMap.Get("Link"))
 	assert.Equal(ts.T(), "1", w.HeaderMap.Get("X-Total-Count"))
 
-	fmt.Println(w.Body)
 	data := struct {
 		Users []*models.User `json:"users"`
 		Aud   string         `json:"aud"`
@@ -306,6 +305,7 @@ func (ts *AdminTestSuite) TestAdminUserGet() {
 	assert.NotNil(ts.T(), data["app_metadata"])
 	assert.NotNil(ts.T(), data["user_metadata"])
 	md := data["user_metadata"].(map[string]interface{})
+	assert.Len(ts.T(), md, 1)
 	assert.Equal(ts.T(), "Test Get User", md["full_name"])
 }
 

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -38,7 +38,6 @@ func TestAdmin(t *testing.T) {
 		instanceID: instanceID,
 	}
 	defer api.db.Close()
-	//defer api.db.DropDB()
 
 	suite.Run(t, ts)
 }

--- a/api/api.go
+++ b/api/api.go
@@ -13,6 +13,7 @@ import (
 	"github.com/netlify/gotrue/storage/dial"
 	"github.com/netlify/netlify-commons/graceful"
 	"github.com/rs/cors"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sebest/xff"
 	"github.com/sirupsen/logrus"
 )
@@ -155,7 +156,7 @@ func NewAPIFromConfigFile(filename string, version string) (*API, *conf.Configur
 		return nil, nil, err
 	}
 
-	ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, config, "")
+	ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, config, uuid.Nil)
 	if err != nil {
 		logrus.Fatalf("Error loading instance config: %+v", err)
 	}
@@ -176,7 +177,7 @@ func (a *API) HealthCheck(w http.ResponseWriter, r *http.Request) error {
 	})
 }
 
-func WithInstanceConfig(ctx context.Context, smtp conf.SMTPConfiguration, config *conf.Configuration, instanceID string) (context.Context, error) {
+func WithInstanceConfig(ctx context.Context, smtp conf.SMTPConfiguration, config *conf.Configuration, instanceID uuid.UUID) (context.Context, error) {
 	ctx = withConfig(ctx, config)
 
 	mailer := mailer.NewMailer(smtp, config)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -61,25 +61,14 @@ func setupAPIForTestWithCallback(cb func(*conf.GlobalConfiguration, *conf.Config
 		return nil, nil, err
 	}
 
-	// TODO disable serial tests and re-enable automigrate and uncomment
-	// this code once `pop` migrations are fixed
-	//
-	// dbname := fmt.Sprintf("gotrue_test_%s", randStringBytes(10))
-	// globalConfig.DB.URL, err = test.CreateTestDB(dbname, globalConfig)
-	// if err != nil {
-	// 	return nil, nil, err
-	// }
-
 	conn, err := test.SetupDBConnection(globalConfig)
 	if err != nil {
-		//test.DeleteTestDB(globalConfig)
 		return nil, nil, err
 	}
 
 	config, err := conf.LoadConfig(apiTestConfig)
 	if err != nil {
 		conn.Close()
-		//test.DeleteTestDB(globalConfig)
 		return nil, nil, err
 	}
 
@@ -88,7 +77,6 @@ func setupAPIForTestWithCallback(cb func(*conf.GlobalConfiguration, *conf.Config
 		instanceID, err = cb(globalConfig, config, conn)
 		if err != nil {
 			conn.Close()
-			//test.DeleteTestDB(globalConfig)
 			return nil, nil, err
 		}
 	}
@@ -96,7 +84,6 @@ func setupAPIForTestWithCallback(cb func(*conf.GlobalConfiguration, *conf.Config
 	ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, config, instanceID)
 	if err != nil {
 		conn.Close()
-		//test.DeleteTestDB(globalConfig)
 		return nil, nil, err
 	}
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -2,18 +2,24 @@ package api
 
 import (
 	"context"
+	"math/rand"
+	"time"
 
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage"
 	"github.com/netlify/gotrue/storage/test"
-	"github.com/pborman/uuid"
+	"github.com/satori/go.uuid"
 )
 
 const (
 	apiTestVersion = "1"
 	apiTestConfig  = "../hack/test.env"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 // setupAPIForTest creates a new API to run tests with.
 // Using this function allows us to keep track of the database connection
@@ -23,17 +29,17 @@ func setupAPIForTest() (*API, *conf.Configuration, error) {
 }
 
 func setupAPIForMultiinstanceTest() (*API, *conf.Configuration, error) {
-	cb := func(gc *conf.GlobalConfiguration, c *conf.Configuration, conn storage.Connection) (string, error) {
+	cb := func(gc *conf.GlobalConfiguration, c *conf.Configuration, conn storage.Connection) (uuid.UUID, error) {
 		gc.MultiInstanceMode = true
-		return "", nil
+		return uuid.Nil, nil
 	}
 
 	return setupAPIForTestWithCallback(cb)
 }
 
-func setupAPIForTestForInstance() (*API, *conf.Configuration, string, error) {
-	instanceID := uuid.NewRandom().String()
-	cb := func(gc *conf.GlobalConfiguration, c *conf.Configuration, conn storage.Connection) (string, error) {
+func setupAPIForTestForInstance() (*API, *conf.Configuration, uuid.UUID, error) {
+	instanceID := uuid.Must(uuid.NewV4())
+	cb := func(gc *conf.GlobalConfiguration, c *conf.Configuration, conn storage.Connection) (uuid.UUID, error) {
 		err := conn.CreateInstance(&models.Instance{
 			ID:         instanceID,
 			UUID:       testUUID,
@@ -44,34 +50,65 @@ func setupAPIForTestForInstance() (*API, *conf.Configuration, string, error) {
 
 	api, conf, err := setupAPIForTestWithCallback(cb)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, uuid.Nil, err
 	}
 	return api, conf, instanceID, nil
 }
 
-func setupAPIForTestWithCallback(cb func(*conf.GlobalConfiguration, *conf.Configuration, storage.Connection) (string, error)) (*API, *conf.Configuration, error) {
-	globalConfig, conn, err := test.SetupDBConnection()
+func setupAPIForTestWithCallback(cb func(*conf.GlobalConfiguration, *conf.Configuration, storage.Connection) (uuid.UUID, error)) (*API, *conf.Configuration, error) {
+	globalConfig, err := conf.LoadGlobal(apiTestConfig)
 	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO disable serial tests and re-enable automigrate and uncomment
+	// this code once `pop` migrations are fixed
+	//
+	// dbname := fmt.Sprintf("gotrue_test_%s", randStringBytes(10))
+	// globalConfig.DB.URL, err = test.CreateTestDB(dbname, globalConfig)
+	// if err != nil {
+	// 	return nil, nil, err
+	// }
+
+	conn, err := test.SetupDBConnection(globalConfig)
+	if err != nil {
+		//test.DeleteTestDB(globalConfig)
 		return nil, nil, err
 	}
 
 	config, err := conf.LoadConfig(apiTestConfig)
 	if err != nil {
+		conn.Close()
+		//test.DeleteTestDB(globalConfig)
 		return nil, nil, err
 	}
 
-	instanceID := ""
+	instanceID := uuid.Nil
 	if cb != nil {
 		instanceID, err = cb(globalConfig, config, conn)
 		if err != nil {
+			conn.Close()
+			//test.DeleteTestDB(globalConfig)
 			return nil, nil, err
 		}
 	}
 
 	ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, config, instanceID)
 	if err != nil {
+		conn.Close()
+		//test.DeleteTestDB(globalConfig)
 		return nil, nil, err
 	}
 
 	return NewAPIWithVersion(ctx, globalConfig, conn, apiTestVersion), config, nil
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func randStringBytes(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))]
+	}
+	return string(b)
 }

--- a/api/auth.go
+++ b/api/auth.go
@@ -27,7 +27,7 @@ func (a *API) requireAdmin(ctx context.Context, w http.ResponseWriter, r *http.R
 	// Find the administrative user
 	adminUser, err := getUserFromClaims(ctx, a.db)
 	if err != nil {
-		return nil, unauthorizedError("Invalid admin user")
+		return nil, unauthorizedError("Invalid admin user").WithInternalError(err)
 	}
 
 	aud := a.requestAud(ctx, r)

--- a/api/context.go
+++ b/api/context.go
@@ -7,6 +7,7 @@ import (
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/mailer"
 	"github.com/netlify/gotrue/models"
+	uuid "github.com/satori/go.uuid"
 )
 
 type contextKey string
@@ -96,17 +97,17 @@ func getMailer(ctx context.Context) mailer.Mailer {
 }
 
 // withInstanceID adds the instance id to the context.
-func withInstanceID(ctx context.Context, id string) context.Context {
+func withInstanceID(ctx context.Context, id uuid.UUID) context.Context {
 	return context.WithValue(ctx, instanceIDKey, id)
 }
 
 // getInstanceID reads the instance id from the context.
-func getInstanceID(ctx context.Context) string {
+func getInstanceID(ctx context.Context) uuid.UUID {
 	obj := ctx.Value(instanceIDKey)
 	if obj == nil {
-		return ""
+		return uuid.Nil
 	}
-	return obj.(string)
+	return obj.(uuid.UUID)
 }
 
 // withInstance adds the instance id to the context.

--- a/api/external.go
+++ b/api/external.go
@@ -68,7 +68,7 @@ func (a *API) ExternalProviderRedirect(w http.ResponseWriter, r *http.Request) e
 				ExpiresAt: time.Now().Add(5 * time.Minute).Unix(),
 			},
 			SiteURL:    config.SiteURL,
-			InstanceID: getInstanceID(ctx),
+			InstanceID: getInstanceID(ctx).String(),
 			NetlifyID:  getNetlifyID(ctx),
 		},
 		Provider:    providerType,

--- a/api/external_test.go
+++ b/api/external_test.go
@@ -9,7 +9,7 @@ import (
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/storage/test"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -18,7 +18,7 @@ type ExternalTestSuite struct {
 	suite.Suite
 	API        *API
 	Config     *conf.Configuration
-	instanceID string
+	instanceID uuid.UUID
 }
 
 func TestExternal(t *testing.T) {
@@ -30,12 +30,14 @@ func TestExternal(t *testing.T) {
 		Config:     config,
 		instanceID: instanceID,
 	}
+	defer api.db.Close()
+	//defer api.db.DropDB()
 
 	suite.Run(t, ts)
 }
 
 func (ts *ExternalTestSuite) SetupTest() {
-	test.CleanupTables()
+	ts.API.db.TruncateAll()
 }
 
 // TestSignupExternalUnsupported tests API /authorize for an unsupported external provider

--- a/api/external_test.go
+++ b/api/external_test.go
@@ -31,7 +31,6 @@ func TestExternal(t *testing.T) {
 		instanceID: instanceID,
 	}
 	defer api.db.Close()
-	//defer api.db.DropDB()
 
 	suite.Run(t, ts)
 }

--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -10,12 +10,14 @@ import (
 
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSignupHookSendInstanceID(t *testing.T) {
-	user, err := models.NewUser("myinstance", "test@truth.com", "thisisapassword", "", nil)
+	iid := uuid.Must(uuid.NewV4())
+	user, err := models.NewUser(iid, "test@truth.com", "thisisapassword", "", nil)
 	require.NoError(t, err)
 
 	var callCount int
@@ -29,7 +31,7 @@ func TestSignupHookSendInstanceID(t *testing.T) {
 		require.NoError(t, json.Unmarshal(raw, &data))
 
 		assert.Len(t, data, 3)
-		assert.Equal(t, "myinstance", data["instance_id"])
+		assert.Equal(t, iid.String(), data["instance_id"])
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer svr.Close()
@@ -40,7 +42,7 @@ func TestSignupHookSendInstanceID(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, triggerHook(SignupEvent, user, "myinstance", config))
+	require.NoError(t, triggerHook(SignupEvent, user, iid, config))
 
 	assert.Equal(t, 1, callCount)
 }

--- a/api/hooks.go
+++ b/api/hooks.go
@@ -12,6 +12,7 @@ import (
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 
 	"github.com/netlify/gotrue/conf"
@@ -34,7 +35,7 @@ var defaultTimeout time.Duration = time.Second * 5
 type Webhook struct {
 	*conf.WebhookConfig
 
-	instanceID string
+	instanceID uuid.UUID
 	jwtSecret  string
 	claims     jwt.Claims
 	payload    []byte
@@ -142,7 +143,7 @@ func closeBody(rsp *http.Response) {
 	}
 }
 
-func triggerHook(event HookEvent, user *models.User, instanceID string, config *conf.Configuration) error {
+func triggerHook(event HookEvent, user *models.User, instanceID uuid.UUID, config *conf.Configuration) error {
 	if config.Webhook.URL == "" {
 		return nil
 	}
@@ -163,7 +164,7 @@ func triggerHook(event HookEvent, user *models.User, instanceID string, config *
 
 	payload := struct {
 		Event      HookEvent    `json:"event"`
-		InstanceID string       `json:"instance_id,omitempty"`
+		InstanceID uuid.UUID    `json:"instance_id,omitempty"`
 		User       *models.User `json:"user"`
 	}{
 		Event:      event,
@@ -180,7 +181,7 @@ func triggerHook(event HookEvent, user *models.User, instanceID string, config *
 		instanceID:    instanceID,
 		claims: &jwt.StandardClaims{
 			IssuedAt: time.Now().Unix(),
-			Subject:  instanceID,
+			Subject:  instanceID.String(),
 			Issuer:   gotrueIssuer,
 		},
 		payload: data,

--- a/api/instance_test.go
+++ b/api/instance_test.go
@@ -35,7 +35,6 @@ func TestInstance(t *testing.T) {
 		API: api,
 	}
 	defer api.db.Close()
-	//defer api.db.DropDB()
 
 	suite.Run(t, ts)
 }

--- a/api/invite_test.go
+++ b/api/invite_test.go
@@ -38,7 +38,6 @@ func TestInvite(t *testing.T) {
 		instanceID: instanceID,
 	}
 	defer api.db.Close()
-	//defer api.db.DropDB()
 
 	suite.Run(t, ts)
 }

--- a/api/invite_test.go
+++ b/api/invite_test.go
@@ -13,7 +13,7 @@ import (
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage/test"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -25,7 +25,7 @@ type InviteTestSuite struct {
 	Config *conf.Configuration
 
 	token      string
-	instanceID string
+	instanceID uuid.UUID
 }
 
 func TestInvite(t *testing.T) {
@@ -37,12 +37,14 @@ func TestInvite(t *testing.T) {
 		Config:     config,
 		instanceID: instanceID,
 	}
+	defer api.db.Close()
+	//defer api.db.DropDB()
 
 	suite.Run(t, ts)
 }
 
 func (ts *InviteTestSuite) SetupTest() {
-	test.CleanupTables()
+	ts.API.db.TruncateAll()
 
 	// Setup response recorder with super admin privileges
 	ts.token = ts.makeSuperAdmin("admin@example.com")

--- a/api/logout.go
+++ b/api/logout.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"net/http"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 // Logout is the endpoint for logging out a user and thereby revoking any refresh tokens
@@ -11,11 +13,15 @@ func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 
 	a.clearCookieToken(ctx, w)
 
-	if claims == nil || claims.Subject == "" {
+	if claims == nil {
 		return badRequestError("Could not read User ID claim")
 	}
+	userID, err := uuid.FromString(claims.Subject)
+	if err != nil {
+		return badRequestError("Invalid User ID")
+	}
 
-	a.db.Logout(claims.Subject)
+	a.db.Logout(userID)
 	w.WriteHeader(http.StatusNoContent)
 
 	return nil

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -7,8 +7,9 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/netlify/gotrue/models"
+	uuid "github.com/satori/go.uuid"
 )
 
 const (
@@ -68,9 +69,12 @@ func (a *API) loadInstanceConfig(w http.ResponseWriter, r *http.Request) (contex
 		return nil, badRequestError("Operator microservice signature is invalid: %v", err)
 	}
 
-	instanceID := claims.InstanceID
-	if instanceID == "" {
+	if claims.InstanceID == "" {
 		return nil, badRequestError("Instance ID is missing")
+	}
+	instanceID, err := uuid.FromString(claims.InstanceID)
+	if err != nil {
+		return nil, badRequestError("Instance ID is not a valid UUID")
 	}
 
 	logEntrySetField(r, "instance_id", instanceID)

--- a/api/recover_test.go
+++ b/api/recover_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage/test"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -21,7 +21,7 @@ type RecoverTestSuite struct {
 	API    *API
 	Config *conf.Configuration
 
-	instanceID string
+	instanceID uuid.UUID
 }
 
 func TestRecover(t *testing.T) {
@@ -33,12 +33,14 @@ func TestRecover(t *testing.T) {
 		Config:     config,
 		instanceID: instanceID,
 	}
+	defer api.db.Close()
+	//defer api.db.DropDB()
 
 	suite.Run(t, ts)
 }
 
 func (ts *RecoverTestSuite) SetupTest() {
-	test.CleanupTables()
+	ts.API.db.TruncateAll()
 
 	// Create user
 	u, err := models.NewUser(ts.instanceID, "test@example.com", "password", ts.Config.JWT.Aud, nil)

--- a/api/recover_test.go
+++ b/api/recover_test.go
@@ -34,7 +34,6 @@ func TestRecover(t *testing.T) {
 		instanceID: instanceID,
 	}
 	defer api.db.Close()
-	//defer api.db.DropDB()
 
 	suite.Run(t, ts)
 }

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -36,7 +36,6 @@ func TestSignup(t *testing.T) {
 		instanceID: instanceID,
 	}
 	defer api.db.Close()
-	//defer api.db.DropDB()
 
 	suite.Run(t, ts)
 }

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -12,7 +12,7 @@ import (
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage/test"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -23,7 +23,7 @@ type SignupTestSuite struct {
 	API    *API
 	Config *conf.Configuration
 
-	instanceID string
+	instanceID uuid.UUID
 }
 
 func TestSignup(t *testing.T) {
@@ -35,12 +35,14 @@ func TestSignup(t *testing.T) {
 		Config:     config,
 		instanceID: instanceID,
 	}
+	defer api.db.Close()
+	//defer api.db.DropDB()
 
 	suite.Run(t, ts)
 }
 
 func (ts *SignupTestSuite) SetupTest() {
-	test.CleanupTables()
+	ts.API.db.TruncateAll()
 	ts.Config.Webhook = conf.WebhookConfig{}
 }
 
@@ -92,7 +94,7 @@ func (ts *SignupTestSuite) TestWebhookTriggered() {
 			return []byte(ts.Config.Webhook.Secret), nil
 		})
 		assert.True(token.Valid)
-		assert.Equal(ts.instanceID, claims.Subject) // not configured for multitenancy
+		assert.Equal(ts.instanceID.String(), claims.Subject) // not configured for multitenancy
 		assert.Equal("gotrue", claims.Issuer)
 		assert.WithinDuration(time.Now(), time.Unix(claims.IssuedAt, 0), 5*time.Second)
 
@@ -106,7 +108,7 @@ func (ts *SignupTestSuite) TestWebhookTriggered() {
 
 		assert.Equal(3, len(data))
 		assert.Equal("validate", data["event"])
-		assert.Equal(ts.instanceID, data["instance_id"])
+		assert.Equal(ts.instanceID.String(), data["instance_id"])
 
 		u, ok := data["user"].(map[string]interface{})
 		require.True(ok)

--- a/api/token.go
+++ b/api/token.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
 )
@@ -136,7 +136,7 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 func generateAccessToken(user *models.User, expiresIn time.Duration, secret string) (string, error) {
 	claims := &GoTrueClaims{
 		StandardClaims: jwt.StandardClaims{
-			Subject:   user.ID,
+			Subject:   user.ID.String(),
 			Audience:  user.Aud,
 			ExpiresAt: time.Now().Add(expiresIn).Unix(),
 		},

--- a/api/user.go
+++ b/api/user.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/netlify/gotrue/models"
+	uuid "github.com/satori/go.uuid"
 )
 
 // UserUpdateParams parameters for updating a user
@@ -24,7 +25,8 @@ func (a *API) UserGet(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Could not read claims")
 	}
 
-	if claims.Subject == "" {
+	userID, err := uuid.FromString(claims.Subject)
+	if err != nil {
 		return badRequestError("Could not read User ID claim")
 	}
 
@@ -33,7 +35,7 @@ func (a *API) UserGet(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Token audience doesn't match request audience")
 	}
 
-	user, err := a.db.FindUserByID(claims.Subject)
+	user, err := a.db.FindUserByID(userID)
 	if err != nil {
 		if models.IsNotFoundError(err) {
 			return notFoundError(err.Error())
@@ -57,11 +59,12 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	claims := getClaims(ctx)
-	if claims.Subject == "" {
+	userID, err := uuid.FromString(claims.Subject)
+	if err != nil {
 		return badRequestError("Could not read User ID claim")
 	}
 
-	user, err := a.db.FindUserByID(claims.Subject)
+	user, err := a.db.FindUserByID(userID)
 	if err != nil {
 		if models.IsNotFoundError(err) {
 			return notFoundError(err.Error())

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -35,7 +35,6 @@ func TestUser(t *testing.T) {
 		instanceID: instanceID,
 	}
 	defer api.db.Close()
-	//defer api.db.DropDB()
 
 	suite.Run(t, ts)
 }

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage/test"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -22,7 +22,7 @@ type UserTestSuite struct {
 	API    *API
 	Config *conf.Configuration
 
-	instanceID string
+	instanceID uuid.UUID
 }
 
 func TestUser(t *testing.T) {
@@ -34,12 +34,14 @@ func TestUser(t *testing.T) {
 		Config:     config,
 		instanceID: instanceID,
 	}
+	defer api.db.Close()
+	//defer api.db.DropDB()
 
 	suite.Run(t, ts)
 }
 
 func (ts *UserTestSuite) SetupTest() {
-	test.CleanupTables()
+	ts.API.db.TruncateAll()
 
 	// Create user
 	u, err := models.NewUser(ts.instanceID, "test@example.com", "password", ts.Config.JWT.Aud, nil)

--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage/test"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -21,7 +21,7 @@ type VerifyTestSuite struct {
 	API    *API
 	Config *conf.Configuration
 
-	instanceID string
+	instanceID uuid.UUID
 }
 
 func TestVerify(t *testing.T) {
@@ -33,12 +33,14 @@ func TestVerify(t *testing.T) {
 		Config:     config,
 		instanceID: instanceID,
 	}
+	defer api.db.Close()
+	//defer api.db.DropDB()
 
 	suite.Run(t, ts)
 }
 
 func (ts *VerifyTestSuite) SetupTest() {
-	test.CleanupTables()
+	ts.API.db.TruncateAll()
 
 	// Create user
 	u, err := models.NewUser(ts.instanceID, "test@example.com", "password", ts.Config.JWT.Aud, nil)

--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -34,7 +34,6 @@ func TestVerify(t *testing.T) {
 		instanceID: instanceID,
 	}
 	defer api.db.Close()
-	//defer api.db.DropDB()
 
 	suite.Run(t, ts)
 }

--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/netlify/gotrue/api"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/storage/dial"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -26,7 +27,7 @@ func serve(globalConfig *conf.GlobalConfiguration, config *conf.Configuration) {
 	}
 	defer db.Close()
 
-	ctx, err := api.WithInstanceConfig(context.Background(), globalConfig.SMTP, config, "")
+	ctx, err := api.WithInstanceConfig(context.Background(), globalConfig.SMTP, config, uuid.Nil)
 	if err != nil {
 		logrus.Fatalf("Error loading instance config: %+v", err)
 	}

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -1,6 +1,8 @@
 package conf
 
 import (
+	"database/sql/driver"
+	"encoding/json"
 	"errors"
 	"os"
 	"time"
@@ -21,11 +23,10 @@ type OAuthProviderConfiguration struct {
 
 // DBConfiguration holds all the database related configuration.
 type DBConfiguration struct {
-	Dialect     string `json:"dialect"`
-	Driver      string `json:"driver" required:"true"`
-	URL         string `json:"url" envconfig:"DATABASE_URL" required:"true"`
-	Namespace   string `json:"namespace"`
-	Automigrate bool   `json:"automigrate"`
+	Driver    string `json:"driver" required:"true"`
+	URL       string `json:"url" envconfig:"DATABASE_URL" required:"true"`
+	Namespace string `json:"namespace"`
+	// Automigrate bool   `json:"automigrate"`
 }
 
 // JWTConfiguration holds all the JWT related configuration.
@@ -198,6 +199,31 @@ func (config *Configuration) ApplyDefaults() {
 	if config.Cookie.Duration == 0 {
 		config.Cookie.Duration = 86400
 	}
+}
+
+func (config *Configuration) Value() (driver.Value, error) {
+	data, err := json.Marshal(config)
+	if err != nil {
+		return driver.Value(""), err
+	}
+	return driver.Value(string(data)), nil
+}
+
+func (config *Configuration) Scan(src interface{}) error {
+	var source []byte
+	switch v := src.(type) {
+	case string:
+		source = []byte(v)
+	case []byte:
+		source = v
+	default:
+		return errors.New("Invalid data type for Configuration")
+	}
+
+	if len(source) == 0 {
+		source = []byte("{}")
+	}
+	return json.Unmarshal(source, &config)
 }
 
 func (o *OAuthProviderConfiguration) Validate() error {

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -26,7 +26,6 @@ type DBConfiguration struct {
 	Driver    string `json:"driver" required:"true"`
 	URL       string `json:"url" envconfig:"DATABASE_URL" required:"true"`
 	Namespace string `json:"namespace"`
-	// Automigrate bool   `json:"automigrate"`
 }
 
 // JWTConfiguration holds all the JWT related configuration.

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: cdc3a5f427a631f52c96cc81940727f3124d2e34f9bade39e316dd06d75a1a5c
-updated: 2018-01-03T16:22:37.007105-05:00
+hash: 8443ccd50300b776e8dbd5083b332987d45a27279d857e849de49ab081faebbd
+updated: 2018-01-04T18:53:17.112287-05:00
 imports:
 - name: cloud.google.com/go
   version: 98f5696b1026056a47f114c4451dbc4703d67191
@@ -7,8 +7,12 @@ imports:
   - compute/metadata
 - name: github.com/badoux/checkmail
   version: d0a759655d62bcdc95c50a0676f3e9702ed59453
+- name: github.com/daviddengcn/go-colortext
+  version: 17e75f6184bc9e727756cd0d82e0af58b1fc7191
 - name: github.com/dgrijalva/jwt-go
   version: d2709f9f1f31ebcda9651b03077758c1f3a0018c
+- name: github.com/fatih/color
+  version: 5df930a27be2502f99b292b7cc09ebad4d0891f4
 - name: github.com/fsnotify/fsnotify
   version: f12c6236fe7b5cf6bcf30e5935d08cb079d78334
 - name: github.com/go-chi/chi
@@ -17,6 +21,10 @@ imports:
   - middleware
 - name: github.com/go-sql-driver/mysql
   version: a0583e0143b1624142adab07e0e97fe106d99561
+- name: github.com/gobuffalo/envy
+  version: a1789093e51b497900a240e15b39d8a97bfbc5d0
+- name: github.com/gobuffalo/packr
+  version: 7458c919b2ddc10bfb5588b6645b7aefd1c60418
 - name: github.com/golang/protobuf
   version: ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e
   subpackages:
@@ -27,7 +35,6 @@ imports:
   - logging
   - proxy/certs
   - proxy/dialers/mysql
-  - proxy/dialers/postgres
   - proxy/proxy
   - proxy/util
 - name: github.com/hashicorp/hcl
@@ -45,10 +52,10 @@ imports:
   version: 3e95a51e0639b4cf372f2ccf74c86749d747fbdc
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
-- name: github.com/jinzhu/gorm
-  version: 0a51f6cdc55d1650d9ed3b4c13026cfa9133b01e
-- name: github.com/jinzhu/inflection
-  version: 1c35d901db3da928c72a72d8458480cc9ade058f
+- name: github.com/jmoiron/sqlx
+  version: de8647470aafe4854c976707c431dbe1eb2822c6
+  subpackages:
+  - reflectx
 - name: github.com/joho/godotenv
   version: 726cc8b906e3d31c70a9671c90a13716a8d3f50d
 - name: github.com/kelseyhightower/envconfig
@@ -63,6 +70,63 @@ imports:
   - oid
 - name: github.com/magiconair/properties
   version: 0723e352fa358f9322c938cc2dadda874e9151a9
+- name: github.com/markbates/going
+  version: 0576708c56cea02331f864fe6e157ac7841923e4
+  subpackages:
+  - defaults
+  - randx
+  - wait
+- name: github.com/markbates/inflect
+  version: a12c3aec81a6a938bf584a4bac567afed9256586
+- name: github.com/markbates/pop
+  version: b4656b41fc8dbd16e86737e066370f3272746a1d
+  subpackages:
+  - columns
+  - fizz
+  - fizz/translators
+- name: github.com/markbates/validate
+  version: cd8cc34c703420d6b084fbbfd5085e8e71c5b830
+- name: github.com/mattn/anko
+  version: 3b446c7d031bdd754fc0183f599af173cd996715
+  subpackages:
+  - ast
+  - builtins
+  - builtins/encoding/json
+  - builtins/errors
+  - builtins/flag
+  - builtins/fmt
+  - builtins/github.com/daviddengcn/go-colortext
+  - builtins/io
+  - builtins/io/ioutil
+  - builtins/math
+  - builtins/math/big
+  - builtins/math/rand
+  - builtins/net
+  - builtins/net/http
+  - builtins/net/url
+  - builtins/os
+  - builtins/os/exec
+  - builtins/os/signal
+  - builtins/path
+  - builtins/path/filepath
+  - builtins/regexp
+  - builtins/runtime
+  - builtins/sort
+  - builtins/strconv
+  - builtins/strings
+  - builtins/time
+  - parser
+  - vm
+- name: github.com/mattn/go-colorable
+  version: 5411d3eea5978e6cdc258b30de592b60df6aba96
+  repo: https://github.com/mattn/go-colorable
+- name: github.com/mattn/go-isatty
+  version: 57fdcb988a5c543893cc61bce354a6e24ab70022
+  repo: https://github.com/mattn/go-isatty
+- name: github.com/mattn/go-sqlite3
+  version: 3b3f1d01b2696af5501697c35629048c227586ab
+- name: github.com/mitchellh/go-homedir
+  version: b8bc1bf767474819792c23f32d8286a45736f1c6
 - name: github.com/mitchellh/mapstructure
   version: db1efb556f84b25a0a13a04aad883943538ad2e0
 - name: github.com/nats-io/nats
@@ -97,6 +161,8 @@ imports:
   version: 8dd4211afb5d08dbb39a533b9bb9e4b486351df6
 - name: github.com/rybit/nats_logrus_hook
   version: 8d9e8da6aeca6fe5ab668efa91d1ea0722af8d1a
+- name: github.com/satori/go.uuid
+  version: 36e9d2ebbde5e3f13ab2e25625fd453271d6522e
 - name: github.com/sebest/xff
   version: 6c115e0ffa35d6a2e3f7a9e797c9cf07f0da4b9f
 - name: github.com/signalfx/com_signalfx_metrics_protobuf
@@ -162,8 +228,12 @@ imports:
   - internal
   - jws
   - jwt
+- name: golang.org/x/sync
+  version: fd80eb99c8f653c847d294a001bdf2a3a6f768f5
+  subpackages:
+  - errgroup
 - name: golang.org/x/sys
-  version: e48874b42435b4347fc52bdee0424a52abc974d7
+  version: e24f485414aeafb646f6fca458b0bf869c0880a1
   subpackages:
   - unix
 - name: golang.org/x/text

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,8 +2,6 @@ package: github.com/netlify/gotrue
 import:
 - package: github.com/dgrijalva/jwt-go
   version: v3.0.0
-- package: github.com/jinzhu/gorm
-  version: 0a51f6cdc55d1650d9ed3b4c13026cfa9133b01e
 - package: github.com/pborman/uuid
   version: v1.0
 - package: github.com/rs/cors
@@ -32,7 +30,6 @@ import:
   version: v0.8.0
 - package: github.com/go-sql-driver/mysql
   version: v1.3
-- package: github.com/lib/pq
 - package: github.com/spf13/viper
 - package: github.com/go-chi/chi
   version: v3.1.4
@@ -46,8 +43,10 @@ import:
 - package: github.com/GoogleCloudPlatform/cloudsql-proxy
   version: "1.10"
   subpackages:
-  - proxy/dialers/postgres
+  - proxy/dialers/mysql
 - package: github.com/kelseyhightower/envconfig
   version: v1.3.0
 - package: github.com/joho/godotenv
   version: v1.1
+- package: github.com/markbates/pop
+  version: 3.42.0

--- a/hack/test.env
+++ b/hack/test.env
@@ -3,7 +3,7 @@ GOTRUE_JWT_EXP=3600
 GOTRUE_JWT_AUD=api.netlify.com
 GOTRUE_DB_DRIVER=mysql
 GOTRUE_DB_AUTOMIGRATE=true
-DATABASE_URL="root@tcp(127.0.0.1:3306)/gotrue_test?parseTime=true&autocommit=true&sql_mode=TRADITIONAL"
+DATABASE_URL="root@tcp(127.0.0.1:3306)/gotrue_test?parseTime=true&sql_mode=TRADITIONAL"
 GOTRUE_API_HOST=localhost
 PORT=9999
 GOTRUE_LOG_LEVEL=debug

--- a/migrations/20180108183307_drop_instance_deleted_at.down.sql
+++ b/migrations/20180108183307_drop_instance_deleted_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `instances` ADD `deleted_at` timestamp NULL DEFAULT NULL AFTER `updated_at`;

--- a/migrations/20180108183307_drop_instance_deleted_at.up.sql
+++ b/migrations/20180108183307_drop_instance_deleted_at.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `instances` DROP `deleted_at`;

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -28,7 +28,6 @@ CREATE TABLE `instances` (
   `raw_base_config` longtext,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
-  `deleted_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/models/connection.go
+++ b/models/connection.go
@@ -1,21 +1,5 @@
 package models
 
-// Namespace puts all tables names under a common
-// namespace. This is useful if you want to use
-// the same database for several services and don't
-// want table names to collide.
-var Namespace string
-
-// tableName returns the name of a model's table
-// in the database. It uses the namespace to isolate
-// the model when this is set in the configuration.
-func tableName(modelName string) string {
-	if Namespace != "" {
-		return Namespace + "_" + modelName
-	}
-	return modelName
-}
-
 type Pagination struct {
 	Page    uint64
 	PerPage uint64

--- a/models/instance.go
+++ b/models/instance.go
@@ -1,55 +1,24 @@
 package models
 
 import (
-	"encoding/json"
 	"errors"
 	"time"
 
 	"github.com/netlify/gotrue/conf"
+	uuid "github.com/satori/go.uuid"
 )
 
 const baseConfigKey = ""
 
 type Instance struct {
-	ID string `json:"id"`
+	ID uuid.UUID `json:"id" db:"id"`
 	// Netlify UUID
-	UUID string `json:"uuid,omitempty"`
+	UUID uuid.UUID `json:"uuid,omitempty" db:"uuid"`
 
-	// force usage of text column type
-	RawBaseConfig string              `json:"-" gorm:"size:65535"`
-	BaseConfig    *conf.Configuration `json:"config"`
+	BaseConfig *conf.Configuration `json:"config" db:"raw_base_config"`
 
-	CreatedAt time.Time  `json:"created_at"`
-	UpdatedAt time.Time  `json:"updated_at"`
-	DeletedAt *time.Time `json:"deleted_at"`
-}
-
-// TableName returns the table name used for the Instance model
-func (i *Instance) TableName() string {
-	return tableName("instances")
-}
-
-// AfterFind database callback.
-func (i *Instance) AfterFind() error {
-	if i.RawBaseConfig != "" {
-		err := json.Unmarshal([]byte(i.RawBaseConfig), &i.BaseConfig)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// BeforeSave database callback.
-func (i *Instance) BeforeSave() error {
-	if i.BaseConfig != nil {
-		data, err := json.Marshal(i.BaseConfig)
-		if err != nil {
-			return err
-		}
-		i.RawBaseConfig = string(data)
-	}
-	return nil
+	CreatedAt time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
 }
 
 // Config loads the the base configuration values with defaults.

--- a/models/json_map.go
+++ b/models/json_map.go
@@ -1,0 +1,34 @@
+package models
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+)
+
+type JSONMap map[string]interface{}
+
+func (j JSONMap) Value() (driver.Value, error) {
+	data, err := json.Marshal(j)
+	if err != nil {
+		return driver.Value(""), err
+	}
+	return driver.Value(string(data)), nil
+}
+
+func (j JSONMap) Scan(src interface{}) error {
+	var source []byte
+	switch v := src.(type) {
+	case string:
+		source = []byte(v)
+	case []byte:
+		source = v
+	default:
+		return errors.New("Invalid data type for JSONMap")
+	}
+
+	if len(source) == 0 {
+		source = []byte("{}")
+	}
+	return json.Unmarshal(source, &j)
+}

--- a/models/refresh_token.go
+++ b/models/refresh_token.go
@@ -2,24 +2,20 @@ package models
 
 import (
 	"time"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 // RefreshToken is the database model for refresh tokens.
 type RefreshToken struct {
-	InstanceID string `json:"-"`
-	ID         int64
+	InstanceID uuid.UUID `json:"-" db:"instance_id"`
+	ID         int64     `db:"id"`
 
-	Token string
+	Token string `db:"token"`
 
-	User   User
-	UserID string
+	UserID uuid.UUID `db:"user_id"`
 
-	Revoked   bool
-	CreatedAt time.Time
-	UpdatedAt time.Time
-}
-
-// TableName returns the database table name for RefreshToken
-func (*RefreshToken) TableName() string {
-	return tableName("refresh_tokens")
+	Revoked   bool      `db:"revoked"`
+	CreatedAt time.Time `db:"created_at"`
+	UpdatedAt time.Time `db:"updated_at"`
 }

--- a/storage/dial/dial.go
+++ b/storage/dial/dial.go
@@ -2,27 +2,15 @@ package dial
 
 import (
 	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage"
 	"github.com/netlify/gotrue/storage/sql"
 )
 
 // Dial will connect to that storage engine
 func Dial(config *conf.GlobalConfiguration) (storage.Connection, error) {
-	if config.DB.Namespace != "" {
-		models.Namespace = config.DB.Namespace
-	}
-
 	conn, err := sql.Dial(config)
 	if err != nil {
 		return nil, err
-	}
-
-	if config.DB.Automigrate {
-		if err := conn.Automigrate(); err != nil {
-			conn.Close()
-			return nil, err
-		}
 	}
 
 	return conn, nil

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,31 +1,36 @@
 package storage
 
-import "github.com/netlify/gotrue/models"
+import (
+	"github.com/netlify/gotrue/models"
+	uuid "github.com/satori/go.uuid"
+)
 
 // Connection is the interface a storage provider must implement.
 type Connection interface {
 	Close() error
-	Automigrate() error
-	CountOtherUsers(instanceID string, id string) (int, error)
+	TruncateAll() error
+	DropDB() error
+	MigrateUp() error
+	CountOtherUsers(instanceID uuid.UUID, id uuid.UUID) (int, error)
 	CreateUser(user *models.User) error
 	DeleteUser(user *models.User) error
 	UpdateUser(user *models.User) error
 	FindUserByConfirmationToken(token string) (*models.User, error)
-	FindUserByEmailAndAudience(instanceID string, email, aud string) (*models.User, error)
-	FindUserByID(id string) (*models.User, error)
-	FindUserByInstanceIDAndID(instanceID, id string) (*models.User, error)
+	FindUserByEmailAndAudience(instanceID uuid.UUID, email, aud string) (*models.User, error)
+	FindUserByID(id uuid.UUID) (*models.User, error)
+	FindUserByInstanceIDAndID(instanceID, id uuid.UUID) (*models.User, error)
 	FindUserByRecoveryToken(token string) (*models.User, error)
 	FindUserWithRefreshToken(token string) (*models.User, *models.RefreshToken, error)
-	FindUsersInAudience(instanceID string, aud string, pageParams *models.Pagination, sortParams *models.SortParams, filter string) ([]*models.User, error)
+	FindUsersInAudience(instanceID uuid.UUID, aud string, pageParams *models.Pagination, sortParams *models.SortParams, filter string) ([]*models.User, error)
 	GrantAuthenticatedUser(user *models.User) (*models.RefreshToken, error)
 	GrantRefreshTokenSwap(user *models.User, token *models.RefreshToken) (*models.RefreshToken, error)
-	IsDuplicatedEmail(instanceID string, email, aud string) (bool, error)
-	Logout(id string)
+	IsDuplicatedEmail(instanceID uuid.UUID, email, aud string) (bool, error)
+	Logout(id uuid.UUID)
 	RevokeToken(token *models.RefreshToken) error
 	RollbackRefreshTokenSwap(newToken, oldToken *models.RefreshToken) error
 
-	GetInstanceByUUID(uuid string) (*models.Instance, error)
-	GetInstance(instanceID string) (*models.Instance, error)
+	GetInstanceByUUID(uuid uuid.UUID) (*models.Instance, error)
+	GetInstance(instanceID uuid.UUID) (*models.Instance, error)
 	CreateInstance(instance *models.Instance) error
 	DeleteInstance(instance *models.Instance) error
 	UpdateInstance(instance *models.Instance) error

--- a/storage/test/db_setup.go
+++ b/storage/test/db_setup.go
@@ -1,41 +1,46 @@
 package test
 
 import (
-	"fmt"
-
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/storage"
 	"github.com/netlify/gotrue/storage/dial"
-	"github.com/netlify/gotrue/storage/sql"
 )
 
-const (
-	apiTestEnv = "../hack/test.env"
-)
-
-var conn storage.Connection
-
-func SetupDBConnection() (*conf.GlobalConfiguration, storage.Connection, error) {
-	globalConfig, err := conf.LoadGlobal(apiTestEnv)
+func SetupDBConnection(globalConfig *conf.GlobalConfiguration) (storage.Connection, error) {
+	var conn storage.Connection
+	conn, err := dial.Dial(globalConfig)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	conn, err = dial.Dial(globalConfig)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return globalConfig, conn, err
+	// if globalConfig.DB.Automigrate {
+	// 	if err = conn.MigrateUp(); err != nil {
+	// 		conn.Close()
+	// 		return nil, err
+	// 	}
+	// }
+	return conn, err
 }
 
-func CleanupTables() error {
-	sconn, ok := conn.(*sql.Connection)
-	if !ok {
-		return fmt.Errorf("sql connection required for testing")
-	}
+// func CreateTestDB(dbname string, config *conf.GlobalConfiguration) (string, error) {
+// 	dburl := fmt.Sprintf("root@tcp(127.0.0.1:3306)/%s?parseTime=true&multiStatements=true", dbname)
+// 	db, err := pop.NewConnection(&pop.ConnectionDetails{
+// 		Dialect: config.DB.Driver,
+// 		URL:     dburl,
+// 	})
+// 	if err != nil {
+// 		return "", err
+// 	}
+// 	return dburl, pop.CreateDB(db)
+// }
 
-	sconn.TruncateAll()
-
-	return nil
-}
+// func DeleteTestDB(config *conf.GlobalConfiguration) error {
+// 	db, err := pop.NewConnection(&pop.ConnectionDetails{
+// 		Dialect: config.DB.Driver,
+// 		URL:     config.DB.URL,
+// 	})
+// 	if err != nil {
+// 		return err
+// 	}
+// 	return pop.DropDB(db)
+// }

--- a/storage/test/db_setup.go
+++ b/storage/test/db_setup.go
@@ -7,40 +7,5 @@ import (
 )
 
 func SetupDBConnection(globalConfig *conf.GlobalConfiguration) (storage.Connection, error) {
-	var conn storage.Connection
-	conn, err := dial.Dial(globalConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	// if globalConfig.DB.Automigrate {
-	// 	if err = conn.MigrateUp(); err != nil {
-	// 		conn.Close()
-	// 		return nil, err
-	// 	}
-	// }
-	return conn, err
+	return dial.Dial(globalConfig)
 }
-
-// func CreateTestDB(dbname string, config *conf.GlobalConfiguration) (string, error) {
-// 	dburl := fmt.Sprintf("root@tcp(127.0.0.1:3306)/%s?parseTime=true&multiStatements=true", dbname)
-// 	db, err := pop.NewConnection(&pop.ConnectionDetails{
-// 		Dialect: config.DB.Driver,
-// 		URL:     dburl,
-// 	})
-// 	if err != nil {
-// 		return "", err
-// 	}
-// 	return dburl, pop.CreateDB(db)
-// }
-
-// func DeleteTestDB(config *conf.GlobalConfiguration) error {
-// 	db, err := pop.NewConnection(&pop.ConnectionDetails{
-// 		Dialect: config.DB.Driver,
-// 		URL:     config.DB.URL,
-// 	})
-// 	if err != nil {
-// 		return err
-// 	}
-// 	return pop.DropDB(db)
-// }


### PR DESCRIPTION
**- Summary**

`gorm` uses a naive update method which sets all columns. This will cause updates to clobber each other if run in close succession. We are switching to a simpler ORM `pop` as a first step, and then replacing all updates with explicit column mentions.

Change model IDs to UUIDs.
Remove `deleted_at` from instances model.

**- Test plan**

All existing tests pass.

**- Description for the changelog**

Replace gorm with pop.