### PR TITLE
Allow to set hook callbacks in the JWT claims.

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -27,6 +27,7 @@ const (
 	externalProviderTypeKey = contextKey("external_provider_type")
 	userKey                 = contextKey("user")
 	externalReferrerKey     = contextKey("external_referrer")
+	functionHooksKey        = contextKey("function_hooks")
 	adminUserKey            = contextKey("admin_user")
 )
 
@@ -192,6 +193,21 @@ func getExternalReferrer(ctx context.Context) string {
 	}
 
 	return obj.(string)
+}
+
+// withFunctionHooks adds the provided function hooks to the context.
+func withFunctionHooks(ctx context.Context, hooks map[string]string) context.Context {
+	return context.WithValue(ctx, functionHooksKey, hooks)
+}
+
+// getFunctionHooks reads the request ID from the context.
+func getFunctionHooks(ctx context.Context) map[string]string {
+	obj := ctx.Value(functionHooksKey)
+	if obj == nil {
+		return map[string]string{}
+	}
+
+	return obj.(map[string]string)
 }
 
 // withAdminUser adds the admin user to the context.

--- a/api/external.go
+++ b/api/external.go
@@ -182,7 +182,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 					return terr
 				}
 				if config.Webhook.HasEvent("signup") {
-					if terr = triggerHook(tx, SignupEvent, user, instanceID, config); terr != nil {
+					if terr = triggerHook(ctx, tx, SignupEvent, user, instanceID, config); terr != nil {
 						return terr
 					}
 				}
@@ -196,7 +196,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 					return terr
 				}
 				if config.Webhook.HasEvent("login") {
-					if terr = triggerHook(tx, LoginEvent, user, instanceID, config); terr != nil {
+					if terr = triggerHook(ctx, tx, LoginEvent, user, instanceID, config); terr != nil {
 						return terr
 					}
 				}
@@ -257,7 +257,7 @@ func (a *API) processInvite(ctx context.Context, tx *storage.Connection, userDat
 		return nil, err
 	}
 	if config.Webhook.HasEvent("signup") {
-		if err := triggerHook(tx, SignupEvent, user, instanceID, config); err != nil {
+		if err := triggerHook(ctx, tx, SignupEvent, user, instanceID, config); err != nil {
 			return nil, err
 		}
 	}

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -81,11 +81,3 @@ func (a *API) requestAud(ctx context.Context, r *http.Request) string {
 	// Finally, return the default of none of the above methods are successful
 	return config.JWT.Aud
 }
-
-func requestFunctionHooks(ctx context.Context) map[string]string {
-	claims := getClaims(ctx)
-	if claims != nil {
-		return claims.FunctionHooks
-	}
-	return nil
-}

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -81,3 +81,11 @@ func (a *API) requestAud(ctx context.Context, r *http.Request) string {
 	// Finally, return the default of none of the above methods are successful
 	return config.JWT.Aud
 }
+
+func requestFunctionHooks(ctx context.Context) map[string]string {
+	claims := getClaims(ctx)
+	if claims != nil {
+		return claims.FunctionHooks
+	}
+	return nil
+}

--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage/test"
@@ -49,7 +51,62 @@ func TestSignupHookSendInstanceID(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, triggerHook(conn, SignupEvent, user, iid, config))
+	require.NoError(t, triggerHook(context.Background(), conn, SignupEvent, user, iid, config))
+
+	assert.Equal(t, 1, callCount)
+}
+
+func TestSignupHookFromClaims(t *testing.T) {
+	globalConfig, err := conf.LoadGlobal(apiTestConfig)
+	require.NoError(t, err)
+
+	conn, err := test.SetupDBConnection(globalConfig)
+	require.NoError(t, err)
+
+	iid := uuid.Must(uuid.NewV4())
+	user, err := models.NewUser(iid, "test@truth.com", "thisisapassword", "", nil)
+	require.NoError(t, err)
+
+	var callCount int
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		defer squash(r.Body.Close)
+		raw, err := ioutil.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		data := map[string]interface{}{}
+		require.NoError(t, json.Unmarshal(raw, &data))
+
+		assert.Len(t, data, 3)
+		assert.Equal(t, iid.String(), data["instance_id"])
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	config := &conf.Configuration{
+		Webhook: conf.WebhookConfig{
+			Events: []string{"signup"},
+		},
+		JWT: conf.JWTConfiguration{
+			Secret: "foobar",
+		},
+	}
+
+	ctx := context.Background()
+
+	claims := &GoTrueClaims{
+		StandardClaims: jwt.StandardClaims{
+			Issuer: "netlify",
+		},
+		FunctionHooks: map[string]string{
+			"signup": svr.URL,
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	ctx = withToken(ctx, token)
+
+	require.NoError(t, triggerHook(ctx, conn, SignupEvent, user, iid, config))
 
 	assert.Equal(t, 1, callCount)
 }

--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage/test"
@@ -87,24 +86,12 @@ func TestSignupHookFromClaims(t *testing.T) {
 		Webhook: conf.WebhookConfig{
 			Events: []string{"signup"},
 		},
-		JWT: conf.JWTConfiguration{
-			Secret: "foobar",
-		},
 	}
 
 	ctx := context.Background()
-
-	claims := &GoTrueClaims{
-		StandardClaims: jwt.StandardClaims{
-			Issuer: "netlify",
-		},
-		FunctionHooks: map[string]string{
-			"signup": svr.URL,
-		},
-	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	ctx = withToken(ctx, token)
+	ctx = withFunctionHooks(ctx, map[string]string{
+		"signup": svr.URL,
+	})
 
 	require.NoError(t, triggerHook(ctx, conn, SignupEvent, user, iid, config))
 

--- a/api/hooks.go
+++ b/api/hooks.go
@@ -26,7 +26,7 @@ import (
 type HookEvent string
 
 const (
-	headerHookSignature = "x-gotrue-signature"
+	headerHookSignature = "x-webhook-signature"
 	defaultHookRetries  = 3
 	gotrueIssuer        = "gotrue"
 	ValidateEvent       = "validate"

--- a/api/hooks.go
+++ b/api/hooks.go
@@ -163,7 +163,7 @@ func triggerHook(ctx context.Context, conn *storage.Connection, event HookEvent,
 	}
 
 	if hookURL == nil {
-		fun := requestFunctionHooks(ctx)
+		fun := getFunctionHooks(ctx)
 		if fun == nil {
 			return nil
 		}

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -17,10 +17,11 @@ const (
 )
 
 type NetlifyMicroserviceClaims struct {
-	SiteURL    string `json:"site_url"`
-	InstanceID string `json:"id"`
-	NetlifyID  string `json:"netlify_id"`
 	jwt.StandardClaims
+	SiteURL       string            `json:"site_url"`
+	InstanceID    string            `json:"id"`
+	NetlifyID     string            `json:"netlify_id"`
+	FunctionHooks map[string]string `json:"function_hooks"`
 }
 
 func addGetBody(w http.ResponseWriter, req *http.Request) (context.Context, error) {
@@ -98,6 +99,8 @@ func (a *API) loadInstanceConfig(w http.ResponseWriter, r *http.Request) (contex
 	logEntrySetField(r, "site_url", config.SiteURL)
 
 	ctx = withNetlifyID(ctx, claims.NetlifyID)
+	ctx = withFunctionHooks(ctx, claims.FunctionHooks)
+
 	ctx, err = WithInstanceConfig(ctx, config, instanceID)
 	if err != nil {
 		return nil, internalServerError("Error loading instance config").WithInternalError(err)

--- a/api/signup.go
+++ b/api/signup.go
@@ -71,7 +71,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 				return terr
 			}
 			if config.Webhook.HasEvent("signup") {
-				if terr = triggerHook(tx, SignupEvent, user, instanceID, config); terr != nil {
+				if terr = triggerHook(ctx, tx, SignupEvent, user, instanceID, config); terr != nil {
 					return terr
 				}
 			}
@@ -119,7 +119,7 @@ func (a *API) signupNewUser(conn *storage.Connection, ctx context.Context, param
 			return internalServerError("Database error updating user").WithInternalError(terr)
 		}
 		if config.Webhook.HasEvent("validate") {
-			if terr := triggerHook(tx, ValidateEvent, user, instanceID, config); terr != nil {
+			if terr := triggerHook(ctx, tx, ValidateEvent, user, instanceID, config); terr != nil {
 				return terr
 			}
 		}

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -86,7 +86,7 @@ func (ts *SignupTestSuite) TestWebhookTriggered() {
 		assert.Equal("application/json", r.Header.Get("Content-Type"))
 
 		// verify the signature
-		signature := r.Header.Get("x-gotrue-signature")
+		signature := r.Header.Get("x-webhook-signature")
 		p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
 		claims := new(jwt.StandardClaims)
 		token, err := p.ParseWithClaims(signature, claims, func(token *jwt.Token) (interface{}, error) {

--- a/api/token.go
+++ b/api/token.go
@@ -13,9 +13,10 @@ import (
 
 type GoTrueClaims struct {
 	jwt.StandardClaims
-	Email        string                 `json:"email"`
-	AppMetaData  map[string]interface{} `json:"app_metadata"`
-	UserMetaData map[string]interface{} `json:"user_metadata"`
+	Email         string                 `json:"email"`
+	AppMetaData   map[string]interface{} `json:"app_metadata"`
+	UserMetaData  map[string]interface{} `json:"user_metadata"`
+	FunctionHooks map[string]string      `json:"function_hooks"`
 }
 
 // AccessTokenResponse represents an OAuth2 success response
@@ -77,7 +78,7 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 			return terr
 		}
 		if config.Webhook.HasEvent("login") {
-			if terr = triggerHook(tx, LoginEvent, user, instanceID, config); terr != nil {
+			if terr = triggerHook(ctx, tx, LoginEvent, user, instanceID, config); terr != nil {
 				return terr
 			}
 		}

--- a/api/token.go
+++ b/api/token.go
@@ -13,10 +13,9 @@ import (
 
 type GoTrueClaims struct {
 	jwt.StandardClaims
-	Email         string                 `json:"email"`
-	AppMetaData   map[string]interface{} `json:"app_metadata"`
-	UserMetaData  map[string]interface{} `json:"user_metadata"`
-	FunctionHooks map[string]string      `json:"function_hooks"`
+	Email        string                 `json:"email"`
+	AppMetaData  map[string]interface{} `json:"app_metadata"`
+	UserMetaData map[string]interface{} `json:"user_metadata"`
 }
 
 // AccessTokenResponse represents an OAuth2 success response

--- a/api/verify.go
+++ b/api/verify.go
@@ -107,7 +107,7 @@ func (a *API) signupVerify(ctx context.Context, conn *storage.Connection, params
 		}
 
 		if config.Webhook.HasEvent("signup") {
-			if terr = triggerHook(tx, SignupEvent, user, instanceID, config); terr != nil {
+			if terr = triggerHook(ctx, tx, SignupEvent, user, instanceID, config); terr != nil {
 				return terr
 			}
 		}
@@ -145,7 +145,7 @@ func (a *API) recoverVerify(ctx context.Context, conn *storage.Connection, param
 			}
 
 			if config.Webhook.HasEvent("signup") {
-				if terr = triggerHook(tx, SignupEvent, user, instanceID, config); terr != nil {
+				if terr = triggerHook(ctx, tx, SignupEvent, user, instanceID, config); terr != nil {
 					return terr
 				}
 			}


### PR DESCRIPTION
- An identity provider can set default URL endpoints with them.
- Use the configuration URL if it exists.
- Fallback to JWT claims only if the configuration doesn't explicitly set a URL.

Signed-off-by: David Calavera <david.calavera@gmail.com>