### PR TITLE
Add way to run migrations against namespace tables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
-FROM netlify/go-glide:v0.12.3
+FROM golang:1.9.2
+WORKDIR /go/src/github.com/netlify/gotrue
+COPY . /go/src/github.com/netlify/gotrue/
+RUN make deps build
 
-ADD . /go/src/github.com/netlify/gotrue
-
-RUN useradd -m netlify && cd /go/src/github.com/netlify/gotrue && make deps build && mv gotrue /usr/local/bin/
-
+FROM alpine:3.7
+RUN apk add --no-cache ca-certificates
+RUN adduser -D -u 1000 netlify && mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 USER netlify
+COPY --from=0 /go/src/github.com/netlify/gotrue/gotrue /usr/local/bin/gotrue
+COPY --from=0 /go/src/github.com/netlify/gotrue/migrations /usr/local/etc/gotrue/migrations/
+
+ENV DB_MIGRATIONS_PATH /usr/local/etc/gotrue/migrations
 CMD ["gotrue"]

--- a/cmd/migrate_cmd.go
+++ b/cmd/migrate_cmd.go
@@ -1,8 +1,13 @@
 package cmd
 
 import (
+	"fmt"
+	"net/url"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/markbates/pop"
 	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/storage"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -16,9 +21,68 @@ var migrateCmd = cobra.Command{
 }
 
 func migrate(globalConfig *conf.GlobalConfiguration, config *conf.Configuration) {
-	db, err := storage.Dial(globalConfig)
+	if globalConfig.DB.Driver == "" && globalConfig.DB.URL != "" {
+		u, err := url.Parse(globalConfig.DB.URL)
+		if err != nil {
+			logrus.Fatalf("%+v", errors.Wrap(err, "parsing db connection url"))
+		}
+		globalConfig.DB.Driver = u.Scheme
+	}
+	pop.Debug = true
+
+	deets := &pop.ConnectionDetails{
+		Dialect: globalConfig.DB.Driver,
+		URL:     globalConfig.DB.URL,
+	}
+	if globalConfig.DB.Namespace != "" {
+		deets.Options = map[string]string{
+			"Namespace": globalConfig.DB.Namespace + "_",
+		}
+	}
+
+	db, err := pop.NewConnection(deets)
 	if err != nil {
-		logrus.Fatalf("Error opening database: %+v", err)
+		logrus.Fatalf("%+v", errors.Wrap(err, "opening db connection"))
 	}
 	defer db.Close()
+
+	err = createDB(db)
+	if err != nil {
+		logrus.Fatalf("%+v", errors.Wrap(err, "creating database"))
+	}
+
+	if err := db.Open(); err != nil {
+		logrus.Fatalf("%+v", errors.Wrap(err, "checking database connection"))
+	}
+
+	mig, err := pop.NewFileMigrator(globalConfig.DB.MigrationsPath, db)
+	if err != nil {
+		logrus.Fatalf("%+v", errors.Wrap(err, "creating db migrator"))
+	}
+	// turn off schema dump
+	mig.SchemaPath = ""
+
+	err = mig.Up()
+	if err != nil {
+		logrus.Fatalf("%+v", errors.Wrap(err, "running db migrations"))
+	}
+}
+
+func createDB(conn *pop.Connection) error {
+	deets := conn.Dialect.Details()
+	s := "%s:%s@(%s:%s)/?parseTime=true&multiStatements=true&readTimeout=1s"
+	urlWithoutDb := fmt.Sprintf(s, deets.User, deets.Password, deets.Host, deets.Port)
+
+	db, err := sqlx.Open(deets.Dialect, urlWithoutDb)
+	if err != nil {
+		return errors.Wrapf(err, "error creating MySQL database %s", deets.Database)
+	}
+	defer db.Close()
+	query := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s` DEFAULT COLLATE `utf8mb4_unicode_ci`", deets.Database)
+
+	_, err = db.Exec(query)
+	if err != nil {
+		return errors.Wrapf(err, "error creating MySQL database %s", deets.Database)
+	}
+	return nil
 }

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -23,9 +23,10 @@ type OAuthProviderConfiguration struct {
 
 // DBConfiguration holds all the database related configuration.
 type DBConfiguration struct {
-	Driver    string `json:"driver" required:"true"`
-	URL       string `json:"url" envconfig:"DATABASE_URL" required:"true"`
-	Namespace string `json:"namespace"`
+	Driver         string `json:"driver" required:"true"`
+	URL            string `json:"url" envconfig:"DATABASE_URL" required:"true"`
+	Namespace      string `json:"namespace"`
+	MigrationsPath string `json:"migrations_path" split_words:"true" default:"./migrations"`
 }
 
 // JWTConfiguration holds all the JWT related configuration.

--- a/migrations/20171026211738_create_users.down.sql
+++ b/migrations/20171026211738_create_users.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS `users`;
+DROP TABLE IF EXISTS `{{ index .Options "Namespace" }}users`;

--- a/migrations/20171026211738_create_users.up.sql
+++ b/migrations/20171026211738_create_users.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS `users` (
+CREATE TABLE IF NOT EXISTS `{{ index .Options "Namespace" }}users` (
   `instance_id` varchar(255) DEFAULT NULL,
   `id` varchar(255) NOT NULL,
   `aud` varchar(255) DEFAULT NULL,
@@ -20,8 +20,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `is_super_admin` tinyint(1) DEFAULT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `users_instance_id_idx` (`instance_id`),
+  KEY `users_instance_id_email_idx` (`instance_id`,`email`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE INDEX users_instance_id_idx ON users (instance_id);
-CREATE INDEX users_instance_id_email_idx ON users (instance_id, email);

--- a/migrations/20171026211808_create_instances.down.sql
+++ b/migrations/20171026211808_create_instances.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS `instances`;
+DROP TABLE IF EXISTS `{{ index .Options "Namespace" }}instances`;

--- a/migrations/20171026211808_create_instances.up.sql
+++ b/migrations/20171026211808_create_instances.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS `instances` (
+CREATE TABLE IF NOT EXISTS `{{ index .Options "Namespace" }}instances` (
   `id` varchar(255) NOT NULL,
   `uuid` varchar(255) DEFAULT NULL,
   `raw_base_config` longtext,

--- a/migrations/20171026211834_create_refresh_tokens.down.sql
+++ b/migrations/20171026211834_create_refresh_tokens.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS `refresh_tokens`;
+DROP TABLE IF EXISTS `{{ index .Options "Namespace" }}refresh_tokens`;

--- a/migrations/20171026211834_create_refresh_tokens.up.sql
+++ b/migrations/20171026211834_create_refresh_tokens.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS `refresh_tokens` (
+CREATE TABLE IF NOT EXISTS `{{ index .Options "Namespace" }}refresh_tokens` (
   `instance_id` varchar(255) DEFAULT NULL,
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `token` varchar(255) DEFAULT NULL,
@@ -6,9 +6,8 @@ CREATE TABLE IF NOT EXISTS `refresh_tokens` (
   `revoked` tinyint(1) DEFAULT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `refresh_tokens_instance_id_idx` (`instance_id`),
+  KEY `refresh_tokens_instance_id_user_id_idx` (`instance_id`,`user_id`),
+  KEY `refresh_tokens_token_idx` (`token`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE INDEX refresh_tokens_instance_id_idx ON refresh_tokens (instance_id);
-CREATE INDEX refresh_tokens_instance_id_user_id_idx ON refresh_tokens (instance_id, user_id);
-CREATE INDEX refresh_tokens_token_idx ON refresh_tokens (token);

--- a/migrations/20180103212743_json_user_metadata.down.sql
+++ b/migrations/20180103212743_json_user_metadata.down.sql
@@ -1,3 +1,3 @@
-ALTER TABLE `users` 
+ALTER TABLE `{{ index .Options "Namespace" }}users` 
 CHANGE COLUMN `raw_app_meta_data` `raw_app_meta_data` varchar(255) DEFAULT NULL ,
 CHANGE COLUMN `raw_user_meta_data` `raw_user_meta_data` varchar(255) DEFAULT NULL ;

--- a/migrations/20180103212743_json_user_metadata.up.sql
+++ b/migrations/20180103212743_json_user_metadata.up.sql
@@ -1,8 +1,8 @@
-ALTER TABLE `users` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `{{ index .Options "Namespace" }}users` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
-UPDATE `users` SET `raw_app_meta_data` = '{}' WHERE `raw_app_meta_data` = '';
-UPDATE `users` SET `raw_user_meta_data` = '{}' WHERE `raw_user_meta_data` = '';
+UPDATE `{{ index .Options "Namespace" }}users` SET `raw_app_meta_data` = '{}' WHERE `raw_app_meta_data` = '';
+UPDATE `{{ index .Options "Namespace" }}users` SET `raw_user_meta_data` = '{}' WHERE `raw_user_meta_data` = '';
 
-ALTER TABLE `users` 
+ALTER TABLE `{{ index .Options "Namespace" }}users` 
 CHANGE COLUMN `raw_app_meta_data` `raw_app_meta_data` JSON NULL DEFAULT NULL ,
 CHANGE COLUMN `raw_user_meta_data` `raw_user_meta_data` JSON NULL DEFAULT NULL ;

--- a/migrations/20180108183307_drop_instance_deleted_at.down.sql
+++ b/migrations/20180108183307_drop_instance_deleted_at.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `instances` ADD `deleted_at` timestamp NULL DEFAULT NULL AFTER `updated_at`;
+ALTER TABLE `{{ index .Options "Namespace" }}instances` ADD `deleted_at` timestamp NULL DEFAULT NULL AFTER `updated_at`;

--- a/migrations/20180108183307_drop_instance_deleted_at.up.sql
+++ b/migrations/20180108183307_drop_instance_deleted_at.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `instances` DROP `deleted_at`;
+ALTER TABLE `{{ index .Options "Namespace" }}instances` DROP `deleted_at`;

--- a/migrations/20180119214651_create_audit_log_entries.down.sql
+++ b/migrations/20180119214651_create_audit_log_entries.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS `audit_log_entries`;
+DROP TABLE IF EXISTS `{{ index .Options "Namespace" }}audit_log_entries`;

--- a/migrations/20180119214651_create_audit_log_entries.up.sql
+++ b/migrations/20180119214651_create_audit_log_entries.up.sql
@@ -1,9 +1,8 @@
-CREATE TABLE IF NOT EXISTS `audit_log_entries` (
+CREATE TABLE IF NOT EXISTS `{{ index .Options "Namespace" }}audit_log_entries` (
   `instance_id` varchar(255) DEFAULT NULL,
   `id` varchar(255) NOT NULL,
   `payload` JSON NULL DEFAULT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `audit_logs_instance_id_idx` (`instance_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE INDEX audit_logs_instance_id_idx ON audit_log_entries (instance_id);


### PR DESCRIPTION
**- Summary**

This allows migrations to run against tables that use a prefix. This DOES NOT work for multiple sets of tables in the same db because `soda` does not track versions by table name. 

**- Test plan**

Tested multiple times locally.

**- Description for the changelog**

Add `migrate` command functionality back, with support for namespaces.
