### PR TITLE
fix (GOTRUE_)OPERATOR_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ GOTRUE_SITE_URL=https://example.netlify.com/
 
 The base URL your site is located at. Currently used in combination with other settings to construct URLs used in emails.
 
-`OPERATOR_TOKEN` - `string` *Multi-instance mode only*
+`GOTRUE_OPERATOR_TOKEN` - `string` *Multi-instance mode only*
 
 The shared secret with an operator (usually Netlify) for this microservice. Used to verify requests have been proxied through the operator and
 the payload values can be trusted.


### PR DESCRIPTION
While trying to deploy GoTrue as a Docker container on Heroku and get confuse by the README that was asking me to set `OPERATOR_TOKEN` instead of `GOTRUE_OPERATOR_TOKEN`. This is a simple patch to fix the README. I also wonder if it should be flagged as required? It seems it is when using the Dockerfile at least.

**- Summary**

`OPERATOR_TOKEN` should be `GOTRUE_OPERATOR_TOKEN` in the README.

**- Test plan**

This is a documentation only PR

**- Description for the changelog**

Fix README environment variable name for GOTRUE_OPERATOR_TOKEN

**- A picture of a cute animal (not mandatory but encouraged)**

![nov9cat04](https://user-images.githubusercontent.com/13450/35412568-d7ee497e-021c-11e8-9657-fc7f54dc1584.jpg)
