### PR TITLE
Make Email provider optional, enabled by default.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -90,8 +90,8 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 
 		r.With(api.requireEmailProvider).Post("/signup", api.Signup)
 		r.With(api.requireEmailProvider).Post("/recover", api.Recover)
-		r.With(api.requireEmailProvider).Post("/verify", api.Verify)
 		r.With(api.requireEmailProvider).Post("/token", api.Token)
+		r.Post("/verify", api.Verify)
 
 		r.With(api.requireAuthentication).Post("/logout", api.Logout)
 
@@ -110,7 +110,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 
 			r.Route("/users", func(r *router) {
 				r.Get("/", api.adminUsers)
-				r.Post("/", api.adminUserCreate)
+				r.With(api.requireEmailProvider).Post("/", api.adminUserCreate)
 
 				r.Route("/{user_id}", func(r *router) {
 					r.Use(api.loadUser)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"math/rand"
+	"testing"
 	"time"
 
 	"github.com/netlify/gotrue/conf"
@@ -10,6 +11,7 @@ import (
 	"github.com/netlify/gotrue/storage"
 	"github.com/netlify/gotrue/storage/test"
 	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -88,6 +90,13 @@ func setupAPIForTestWithCallback(cb func(*conf.GlobalConfiguration, *conf.Config
 	}
 
 	return NewAPIWithVersion(ctx, globalConfig, conn, apiTestVersion), config, nil
+}
+
+func TestEmailEnabledByDefault(t *testing.T) {
+	api, _, err := setupAPIForTest()
+	require.NoError(t, err)
+
+	require.True(t, api.config.External.Email.Enabled)
 }
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -142,3 +142,14 @@ func (a *API) requireAdminCredentials(w http.ResponseWriter, req *http.Request) 
 
 	return a.requireAdmin(c, w, req)
 }
+
+func (a *API) requireEmailProvider(w http.ResponseWriter, req *http.Request) (context.Context, error) {
+	ctx := req.Context()
+	config := a.getConfig(ctx)
+
+	if !config.External.Email.Enabled {
+		return nil, badRequestError("Unsupported email provider")
+	}
+
+	return ctx, nil
+}

--- a/api/settings.go
+++ b/api/settings.go
@@ -2,28 +2,32 @@ package api
 
 import "net/http"
 
-type ExternalProviderSettings struct {
-	BitBucket bool `json:"bitbucket"`
+type ProviderSettings struct {
+	Bitbucket bool `json:"bitbucket"`
 	GitHub    bool `json:"github"`
 	GitLab    bool `json:"gitlab"`
 	Google    bool `json:"google"`
+	Facebook  bool `json:"facebook"`
+	Email     bool `json:"email"`
 }
 
 type Settings struct {
-	ExternalProviders ExternalProviderSettings `json:"external"`
-	DisableSignup     bool                     `json:"disable_signup"`
-	Autoconfirm       bool                     `json:"autoconfirm"`
+	ExternalProviders ProviderSettings `json:"external"`
+	DisableSignup     bool             `json:"disable_signup"`
+	Autoconfirm       bool             `json:"autoconfirm"`
 }
 
 func (a *API) Settings(w http.ResponseWriter, r *http.Request) error {
 	config := a.getConfig(r.Context())
 
 	return sendJSON(w, http.StatusOK, &Settings{
-		ExternalProviders: ExternalProviderSettings{
-			BitBucket: config.External.Bitbucket.Enabled,
+		ExternalProviders: ProviderSettings{
+			Bitbucket: config.External.Bitbucket.Enabled,
 			GitHub:    config.External.Github.Enabled,
 			GitLab:    config.External.Gitlab.Enabled,
 			Google:    config.External.Google.Enabled,
+			Facebook:  config.External.Facebook.Enabled,
+			Email:     config.External.Email.Enabled,
 		},
 		DisableSignup: config.DisableSignup,
 		Autoconfirm:   config.Mailer.Autoconfirm,

--- a/api/settings_test.go
+++ b/api/settings_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSettings_DefaultProviders(t *testing.T) {
+	api, _, _, err := setupAPIForTestForInstance()
+	require.NoError(t, err)
+
+	// Setup request
+	req := httptest.NewRequest(http.MethodGet, "http://localhost/settings", nil)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	api.handler.ServeHTTP(w, req)
+	require.Equal(t, w.Code, http.StatusOK)
+	resp := Settings{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	p := resp.ExternalProviders
+	require.True(t, p.Email)
+	require.True(t, p.Google)
+	require.True(t, p.GitHub)
+	require.True(t, p.GitLab)
+	require.True(t, p.Bitbucket)
+	require.False(t, p.Facebook)
+}
+
+func TestSettings_EmailDisabled(t *testing.T) {
+	api, config, instanceID, err := setupAPIForTestForInstance()
+	require.NoError(t, err)
+
+	config.External.Email.Enabled = false
+
+	// Setup request
+	req := httptest.NewRequest(http.MethodGet, "http://localhost/settings", nil)
+	req.Header.Set("Content-Type", "application/json")
+
+	ctx, err := WithInstanceConfig(context.Background(), config, instanceID)
+	require.NoError(t, err)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	api.handler.ServeHTTP(w, req)
+	require.Equal(t, w.Code, http.StatusOK)
+	resp := Settings{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	p := resp.ExternalProviders
+	require.False(t, p.Email)
+}

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -21,6 +21,10 @@ type OAuthProviderConfiguration struct {
 	Enabled     bool   `json:"enabled"`
 }
 
+type EmailProviderConfiguration struct {
+	Enabled bool `json:"enabled" default:"true"`
+}
+
 // DBConfiguration holds all the database related configuration.
 type DBConfiguration struct {
 	Driver         string `json:"driver" required:"true"`
@@ -47,7 +51,7 @@ type GlobalConfiguration struct {
 		RequestIDHeader string `envconfig:"REQUEST_ID_HEADER"`
 	}
 	DB                DBConfiguration
-	External          ExternalProviderConfiguration
+	External          ProviderConfiguration
 	Logging           nconf.LoggingConfig `envconfig:"LOG"`
 	OperatorToken     string              `split_words:"true" required:"true"`
 	MultiInstanceMode bool
@@ -62,12 +66,13 @@ type EmailContentConfiguration struct {
 	EmailChange  string `json:"email_change" split_words:"true"`
 }
 
-type ExternalProviderConfiguration struct {
+type ProviderConfiguration struct {
 	Bitbucket   OAuthProviderConfiguration `json:"bitbucket"`
 	Github      OAuthProviderConfiguration `json:"github"`
 	Gitlab      OAuthProviderConfiguration `json:"gitlab"`
 	Google      OAuthProviderConfiguration `json:"google"`
 	Facebook    OAuthProviderConfiguration `json:"facebook"`
+	Email       EmailProviderConfiguration `json:"email"`
 	RedirectURL string                     `json:"redirect_url"`
 }
 
@@ -91,9 +96,9 @@ type Configuration struct {
 		Templates   EmailContentConfiguration `json:"templates"`
 		URLPaths    EmailContentConfiguration `json:"url_paths"`
 	} `json:"mailer"`
-	External      ExternalProviderConfiguration `json:"external"`
-	DisableSignup bool                          `json:"disable_signup" split_words:"true"`
-	Webhook       WebhookConfig                 `json:"webhook" split_words:"true"`
+	External      ProviderConfiguration `json:"external"`
+	DisableSignup bool                  `json:"disable_signup" split_words:"true"`
+	Webhook       WebhookConfig         `json:"webhook" split_words:"true"`
 	Cookie        struct {
 		Key      string `json:"key"`
 		Duration int    `json:"duration"`


### PR DESCRIPTION
This change adds a new settings to the login providers
to be able to enable/disable email signup/login per instance.

This way, people can use only social logins if they want to.

Fixes #109.

Signed-off-by: David Calavera <david.calavera@gmail.com>