### PR TITLE
Prefix log_type type strings with gotrue

### DIFF
--- a/models/audit_log_entry.go
+++ b/models/audit_log_entry.go
@@ -24,10 +24,10 @@ const (
 	TokenRevokedAction          AuditAction = "token_revoked"
 	TokenRefreshedAction        AuditAction = "token_refreshed"
 
-	account auditLogType = "account"
-	team    auditLogType = "team"
-	token   auditLogType = "token"
-	user    auditLogType = "user"
+	account auditLogType = "gotrue-account"
+	team    auditLogType = "gotrue-team"
+	token   auditLogType = "gotrue-token"
+	user    auditLogType = "gotrue-user"
 )
 
 var actionLogTypeMap = map[AuditAction]auditLogType{


### PR DESCRIPTION
Since some of these log types overlap with bitbaloon log types, can we prefix these with `gotrue-` to make them more easily differentiable from the bitbaloon types?

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/gotrue/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Since we categorize the log types with `log_type`, we are creating a shared name space between all of the audit log APIs.  If we prefix the log_type strings with `gotrue-` it makes them easier to differentiate between bitballoon `team`'s and gotrue `team`s.

**- Test plan**

Open to recommendations

**- Description for the changelog**

- Prefix audit log `log_type` names with `gotrue-`
