### PR TITLE
Use non-deprecated endpoints and correct field names to get Google info

### DIFF
--- a/api/external_test.go
+++ b/api/external_test.go
@@ -135,7 +135,7 @@ func (ts *ExternalTestSuite) TestSignupExternalGoogle() {
 	ts.Equal(ts.Config.External.Google.RedirectURI, q.Get("redirect_uri"))
 	ts.Equal(ts.Config.External.Google.ClientID, q.Get("client_id"))
 	ts.Equal("code", q.Get("response_type"))
-	ts.Equal("https://www.googleapis.com/auth/userinfo.email", q.Get("scope"))
+	ts.Equal("email profile", q.Get("scope"))
 
 	claims := ExternalProviderClaims{}
 	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}

--- a/api/provider/google.go
+++ b/api/provider/google.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
-const googleBaseURL = "https://www.googleapis.com/oauth2/v2/userinfo"
+const googleBaseURL = "https://www.googleapis.com/userinfo/v2/me"
 
 type googleProvider struct {
 	*oauth2.Config
@@ -19,7 +19,7 @@ type googleUser struct {
 	Name          string `json:"name"`
 	AvatarURL     string `json:"picture"`
 	Email         string `json:"email"`
-	EmailVerified bool   `json:"email_verified"`
+	EmailVerified bool   `json:"verified_email"`
 }
 
 // NewGoogleProvider creates a Google account provider.
@@ -34,7 +34,8 @@ func NewGoogleProvider(ext conf.OAuthProviderConfiguration) (Provider, error) {
 			ClientSecret: ext.Secret,
 			Endpoint:     google.Endpoint,
 			Scopes: []string{
-				"https://www.googleapis.com/auth/userinfo.email",
+				"email",
+				"profile",
 			},
 			RedirectURL: ext.RedirectURI,
 		},


### PR DESCRIPTION
**- Summary**
Google accounts were not coming back as email verified. This fixes that, while also using non-deprecated OAuth scopes and API endpoints.

**- Test plan**
Existing tests pass. Will test on staging first.

**- Description for the changelog**
Fix Google email verification status.

