### PR TITLE
Use referrer to determine URL sent in emails

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
@@ -90,4 +91,19 @@ func (a *API) requestAud(ctx context.Context, r *http.Request) string {
 
 	// Finally, return the default of none of the above methods are successful
 	return config.JWT.Aud
+}
+
+func (a *API) getReferrer(r *http.Request) string {
+	ctx := r.Context()
+	config := a.getConfig(ctx)
+	referrer := ""
+	if reqref := r.Referer(); reqref != "" {
+		base, berr := url.Parse(config.SiteURL)
+		refurl, rerr := url.Parse(reqref)
+		// As long as the referrer came from the site, we will redirect back there
+		if berr == nil && rerr == nil && base.Hostname() == refurl.Hostname() {
+			referrer = reqref
+		}
+	}
+	return referrer
 }

--- a/api/invite.go
+++ b/api/invite.go
@@ -60,7 +60,8 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		mailer := a.Mailer(ctx)
-		if err := sendInvite(tx, user, mailer); err != nil {
+		referrer := a.getReferrer(r)
+		if err := sendInvite(tx, user, mailer, referrer); err != nil {
 			return internalServerError("Error inviting user").WithInternalError(err)
 		}
 		return nil

--- a/api/recover.go
+++ b/api/recover.go
@@ -44,7 +44,8 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		mailer := a.Mailer(ctx)
-		return a.sendPasswordRecovery(tx, user, mailer, config.SMTP.MaxFrequency)
+		referrer := a.getReferrer(r)
+		return a.sendPasswordRecovery(tx, user, mailer, config.SMTP.MaxFrequency, referrer)
 	})
 	if err != nil {
 		return internalServerError("Error recovering user").WithInternalError(err)

--- a/api/signup.go
+++ b/api/signup.go
@@ -80,7 +80,8 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 			}
 		} else {
 			mailer := a.Mailer(ctx)
-			if terr = sendConfirmation(tx, user, mailer, config.SMTP.MaxFrequency); terr != nil {
+			referrer := a.getReferrer(r)
+			if terr = sendConfirmation(tx, user, mailer, config.SMTP.MaxFrequency, referrer); terr != nil {
 				return internalServerError("Error sending confirmation mail").WithInternalError(terr)
 			}
 		}

--- a/api/user.go
+++ b/api/user.go
@@ -124,7 +124,8 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			}
 
 			mailer := a.Mailer(ctx)
-			if terr = a.sendEmailChange(tx, user, mailer, params.Email); terr != nil {
+			referrer := a.getReferrer(r)
+			if terr = a.sendEmailChange(tx, user, mailer, params.Email, referrer); terr != nil {
 				return internalServerError("Error sending change email").WithInternalError(terr)
 			}
 		}

--- a/mailer/mailer_test.go
+++ b/mailer/mailer_test.go
@@ -8,19 +8,23 @@ import (
 
 func TestGetSiteURL(t *testing.T) {
 	cases := []struct {
-		SiteURL  string
-		Path     string
-		Fragment string
-		Expected string
+		ReferrerURL string
+		SiteURL     string
+		Path        string
+		Fragment    string
+		Expected    string
 	}{
-		{"https://test.example.com", "/templates/confirm.html", "", "https://test.example.com/templates/confirm.html"},
-		{"https://test.example.com/removedpath", "/templates/confirm.html", "", "https://test.example.com/templates/confirm.html"},
-		{"https://test.example.com/", "/trailingslash/", "", "https://test.example.com/trailingslash/"},
-		{"https://test.example.com", "f", "fragment", "https://test.example.com/f#fragment"},
+		{"", "https://test.example.com", "/templates/confirm.html", "", "https://test.example.com/templates/confirm.html"},
+		{"", "https://test.example.com/removedpath", "/templates/confirm.html", "", "https://test.example.com/templates/confirm.html"},
+		{"", "https://test.example.com/", "/trailingslash/", "", "https://test.example.com/trailingslash/"},
+		{"", "https://test.example.com", "f", "fragment", "https://test.example.com/f#fragment"},
+		{"https://test.example.com/admin", "https://test.example.com", "", "fragment", "https://test.example.com/admin#fragment"},
+		{"https://test.example.com/admin", "https://test.example.com", "f", "fragment", "https://test.example.com/f#fragment"},
+		{"", "https://test.example.com", "", "fragment", "https://test.example.com#fragment"},
 	}
 
 	for _, c := range cases {
-		act, err := getSiteURL(c.SiteURL, c.Path, c.Fragment)
+		act, err := getSiteURL(c.ReferrerURL, c.SiteURL, c.Path, c.Fragment)
 		assert.NoError(t, err, c.Expected)
 		assert.Equal(t, c.Expected, act)
 	}

--- a/mailer/noop.go
+++ b/mailer/noop.go
@@ -9,19 +9,19 @@ func (m noopMailer) ValidateEmail(email string) error {
 	return nil
 }
 
-func (m *noopMailer) InviteMail(user *models.User) error {
+func (m *noopMailer) InviteMail(user *models.User, referrerURL string) error {
 	return nil
 }
 
-func (m *noopMailer) ConfirmationMail(user *models.User) error {
+func (m *noopMailer) ConfirmationMail(user *models.User, referrerURL string) error {
 	return nil
 }
 
-func (m noopMailer) RecoveryMail(user *models.User) error {
+func (m noopMailer) RecoveryMail(user *models.User, referrerURL string) error {
 	return nil
 }
 
-func (m *noopMailer) EmailChangeMail(user *models.User) error {
+func (m *noopMailer) EmailChangeMail(user *models.User, referrerURL string) error {
 	return nil
 }
 

--- a/mailer/template.go
+++ b/mailer/template.go
@@ -41,8 +41,8 @@ func (m TemplateMailer) ValidateEmail(email string) error {
 }
 
 // InviteMail sends a invite mail to a new user
-func (m *TemplateMailer) InviteMail(user *models.User) error {
-	url, err := getSiteURL(m.Config.SiteURL, m.Config.Mailer.URLPaths.Invite, "invite_token="+user.ConfirmationToken)
+func (m *TemplateMailer) InviteMail(user *models.User, referrerURL string) error {
+	url, err := getSiteURL(referrerURL, m.Config.SiteURL, m.Config.Mailer.URLPaths.Invite, "invite_token="+user.ConfirmationToken)
 	if err != nil {
 		return err
 	}
@@ -64,8 +64,8 @@ func (m *TemplateMailer) InviteMail(user *models.User) error {
 }
 
 // ConfirmationMail sends a signup confirmation mail to a new user
-func (m *TemplateMailer) ConfirmationMail(user *models.User) error {
-	url, err := getSiteURL(m.Config.SiteURL, m.Config.Mailer.URLPaths.Confirmation, "confirmation_token="+user.ConfirmationToken)
+func (m *TemplateMailer) ConfirmationMail(user *models.User, referrerURL string) error {
+	url, err := getSiteURL(referrerURL, m.Config.SiteURL, m.Config.Mailer.URLPaths.Confirmation, "confirmation_token="+user.ConfirmationToken)
 	if err != nil {
 		return err
 	}
@@ -87,8 +87,8 @@ func (m *TemplateMailer) ConfirmationMail(user *models.User) error {
 }
 
 // EmailChangeMail sends an email change confirmation mail to a user
-func (m *TemplateMailer) EmailChangeMail(user *models.User) error {
-	url, err := getSiteURL(m.Config.SiteURL, m.Config.Mailer.URLPaths.EmailChange, "email_change_token="+user.EmailChangeToken)
+func (m *TemplateMailer) EmailChangeMail(user *models.User, referrerURL string) error {
+	url, err := getSiteURL(referrerURL, m.Config.SiteURL, m.Config.Mailer.URLPaths.EmailChange, "email_change_token="+user.EmailChangeToken)
 	if err != nil {
 		return err
 	}
@@ -111,8 +111,8 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User) error {
 }
 
 // RecoveryMail sends a password recovery mail
-func (m *TemplateMailer) RecoveryMail(user *models.User) error {
-	url, err := getSiteURL(m.Config.SiteURL, m.Config.Mailer.URLPaths.Recovery, "recovery_token="+user.RecoveryToken)
+func (m *TemplateMailer) RecoveryMail(user *models.User, referrerURL string) error {
+	url, err := getSiteURL(referrerURL, m.Config.SiteURL, m.Config.Mailer.URLPaths.Recovery, "recovery_token="+user.RecoveryToken)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**- Summary**
Fixes #112

**- Test plan**
Added tests for email URL generation function w/ referrer included.

**- Description for the changelog**
Use referrer to determine URL sent in emails.
