### PR TITLE
add login line

### DIFF
--- a/api/token.go
+++ b/api/token.go
@@ -9,6 +9,7 @@ import (
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage"
+	"github.com/sirupsen/logrus"
 )
 
 type GoTrueClaims struct {
@@ -97,6 +98,14 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 	if err != nil {
 		return err
 	}
+
+	// This is a load bearing log - it is used in metering.
+	log := getLogEntry(r)
+	log.WithFields(logrus.Fields{
+		"metering": true,
+		"action":   "login",
+		"user_id":  user.ID.String(),
+	}).Info("Login Completed")
 
 	return sendJSON(w, http.StatusOK, token)
 }

--- a/api/token.go
+++ b/api/token.go
@@ -7,9 +7,9 @@ import (
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/netlify/gotrue/conf"
+	"github.com/netlify/gotrue/metering"
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage"
-	"github.com/sirupsen/logrus"
 )
 
 type GoTrueClaims struct {
@@ -98,15 +98,7 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 	if err != nil {
 		return err
 	}
-
-	// This is a load bearing log - it is used in metering.
-	log := getLogEntry(r)
-	log.WithFields(logrus.Fields{
-		"metering": true,
-		"action":   "login",
-		"user_id":  user.ID.String(),
-	}).Info("Login Completed")
-
+	metering.RecordLogin(r, user.ID, instanceID)
 	return sendJSON(w, http.StatusOK, token)
 }
 

--- a/metering/record.go
+++ b/metering/record.go
@@ -1,0 +1,19 @@
+package metering
+
+import (
+	"net/http"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+)
+
+var logger = logrus.StandardLogger().WithField("metering", true)
+
+func RecordLogin(r *http.Request, userID, instanceID uuid.UUID) {
+	logger.WithFields(logrus.Fields{
+		"action":      "login",
+		"domain":      r.Host,
+		"instance_id": instanceID.String(),
+		"user_id":     userID.String(),
+	}).Info("Login")
+}


### PR DESCRIPTION
Instead of integrating the common's metering package this uses a
simple logrus message. Because these come through k8s, it is
preferable to use stdout. We should work on a way to get a
reliable separate stream, but this will do for now
