### PR TITLE
Fixes for the audit log query builder

### DIFF
--- a/api/audit_test.go
+++ b/api/audit_test.go
@@ -96,6 +96,8 @@ func (ts *AuditTestSuite) TestAuditFilters() {
 	queries := []string{
 		"/admin/audit?query=action:user_deleted",
 		"/admin/audit?query=type:team",
+		"/admin/audit?query=author:user",
+		"/admin/audit?query=author:@example.com",
 	}
 
 	for _, q := range queries {

--- a/models/audit_log_entry.go
+++ b/models/audit_log_entry.go
@@ -82,7 +82,7 @@ func NewAuditLogEntry(tx *storage.Connection, instanceID uuid.UUID, actor *User,
 }
 
 func FindAuditLogEntries(tx *storage.Connection, instanceID uuid.UUID, filterColumns []string, filterValue string, pageParams *Pagination) ([]*AuditLogEntry, error) {
-	q := tx.Q().Where("instance_id = ?", instanceID)
+	q := tx.Q().Order("created_at desc").Where("instance_id = ?", instanceID)
 
 	if len(filterColumns) > 0 && filterValue != "" {
 		lf := "%" + filterValue + "%"

--- a/models/audit_log_entry.go
+++ b/models/audit_log_entry.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"bytes"
 	"fmt"
 	"time"
 
@@ -86,9 +87,21 @@ func FindAuditLogEntries(tx *storage.Connection, instanceID uuid.UUID, filterCol
 
 	if len(filterColumns) > 0 && filterValue != "" {
 		lf := "%" + filterValue + "%"
-		for _, col := range filterColumns {
-			q = q.Where(fmt.Sprintf("payload->>'$.%s' COLLATE utf8mb4_unicode_ci LIKE ?", col), lf)
+
+		builder := bytes.NewBufferString("(")
+		values := make([]interface{}, len(filterColumns))
+
+		for idx, col := range filterColumns {
+			builder.WriteString(fmt.Sprintf("payload->>'$.%s' COLLATE utf8mb4_unicode_ci LIKE ?", col))
+			values[idx] = lf
+
+			if idx+1 < len(filterColumns) {
+				builder.WriteString(" OR ")
+			}
 		}
+		builder.WriteString(")")
+
+		q = q.Where(builder.String(), values...)
 	}
 
 	logs := []*AuditLogEntry{}


### PR DESCRIPTION
- [x] Sort results by most recent event first.
- [x] Use `OR` to filter by different payload columns, rather than `AND`.