### PR TITLE
Add docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+services:
+  gotrue:
+    build: .
+    env_file: .env
+    depends_on:
+      - mysql
+    ports:
+      - 8081:8081
+
+  mysql:
+    image: mysql
+    env_file: .mysql.env
+    restart: always
+    volumes:
+      - gotrue_mysql_data:/var/lib/mysql
+    ports:
+      - 3306:3306
+
+volumes:
+  gotrue_mysql_data:


### PR DESCRIPTION
**- Summary**

This adds a docker-compose.yml file which configures the GoTrue service and a MySQL database for it to connect to (with e.g. `GOTRUE_DB_DATABASE_URL=root:****@tcp(mysql:3306)/gotrue_development`)

**- Notes**

The `ports` entry is set to expose port `8081` - this needs to match the `GOTRUE_API_PORT` environment variable.

As well as running `docker-compose up`, a first run requires `make deps` and `MYSQL_PASSWORD=**** make migrate_dev` to set up the database - this could perhaps be made easier.

**- Description for the changelog**

Add docker-compose.yml.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/14294/36255917-bacb98ba-1248-11e8-9c67-c617efaf6df9.png)

