### PR TITLE
Fix documentation of "type" values for /verify endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ GoTrue exposes the following endpoints:
 
 * **POST /verify**
 
-  Verify a registration or a password recovery. Type can be `signup` or `recover`
+  Verify a registration or a password recovery. Type can be `signup` or `recovery`
   and the `token` is a token returned from either `/signup` or `/recover`.
 
   ```json


### PR DESCRIPTION
**- Summary**

Fix documentation for the `/verify` endpoint.

**- Description for the changelog**

The value of `type` posted to the `/verify` endpoint can be either `signup` or `recovery`.

https://github.com/netlify/gotrue/blob/62c4c9ae17ca432ffc6112c1da440bb7b483047a/api/verify.go#L12-L15
