### PR TITLE
Update default emails to say "user" instead of "account"

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Default Content (if template is unavailable):
 ```html
 <h2>Confirm your signup</h2>
 
-<p>Follow this link to confirm your account:</p>
+<p>Follow this link to confirm your user:</p>
 <p><a href="{{ .ConfirmationURL }}">Confirm your mail</a></p>
 ```
 
@@ -258,7 +258,7 @@ Default Content (if template is unavailable):
 ```html
 <h2>Reset Password</h2>
 
-<p>Follow this link to reset the password for your account:</p>
+<p>Follow this link to reset the password for your user:</p>
 <p><a href="{{ .ConfirmationURL }}">Reset Password</a></p>
 ```
 

--- a/mailer/template.go
+++ b/mailer/template.go
@@ -21,12 +21,12 @@ const defaultInviteMail = `<h2>You have been invited</h2>
 
 const defaultConfirmationMail = `<h2>Confirm your signup</h2>
 
-<p>Follow this link to confirm your account:</p>
+<p>Follow this link to confirm your user:</p>
 <p><a href="{{ .ConfirmationURL }}">Confirm your email address</a></p>`
 
 const defaultRecoveryMail = `<h2>Reset password</h2>
 
-<p>Follow this link to reset the password for your account:</p>
+<p>Follow this link to reset the password for your user:</p>
 <p><a href="{{ .ConfirmationURL }}">Reset password</a></p>`
 
 const defaultEmailChangeMail = `<h2>Confirm email address change</h2>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/gotrue/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Text changes to ensure consistent usage of the term "user" in default emails.
closes https://github.com/netlify/gotrue/issues/203

**- Test plan**

Proofread. Simple word substitution so no further test should be needed.

**- Description for the changelog**

Text changes to ensure consistent usage of the term "user" in default emails.

**- A picture of a cute animal (not mandatory but encouraged)**

![dog_mail](https://user-images.githubusercontent.com/35638702/55756920-8a1df200-5a07-11e9-9da1-d2be8d867a7b.jpg)
