### PR TITLE
Remove extra build step from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ WORKDIR /go/src/github.com/netlify/gotrue
 COPY . /go/src/github.com/netlify/gotrue
 
 RUN make deps build
-RUN go build -a -installsuffix cgo -o gotrue
 
 
 FROM alpine:3.7


### PR DESCRIPTION
**- Summary**
When trying to deploy a new version of gotrue with Marcus, we noticed
the `/health` endpoint wasn't returning version data. After some digging
Marcus found that we're doing double builds in the Docker image, one via
`make build` and then a `go build` after that. The `go build` one
doesn't havee the version info and is redundant given the step before
it.

This change removes the `go build` step so we rely in the makefile one.

**- Test plan**
Verify we get version information on `/health` endpoint.

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://en.bcdn.biz/Images/2018/6/6/6c869cfe-3294-4706-ab2e-1ba98dec747b.jpg)