### PR TITLE
Fix wrong tablename when deleting instance

### DIFF
--- a/models/instance.go
+++ b/models/instance.go
@@ -80,8 +80,8 @@ func GetInstanceByUUID(tx *storage.Connection, uuid uuid.UUID) (*Instance, error
 func DeleteInstance(conn *storage.Connection, instance *Instance) error {
 	return conn.Transaction(func(tx *storage.Connection) error {
 		delModels := map[string]*pop.Model{
-			"user":          &pop.Model{Value: User{}},
-			"refresh token": &pop.Model{Value: RefreshToken{}},
+			"user":          &pop.Model{Value: &User{}},
+			"refresh token": &pop.Model{Value: &RefreshToken{}},
 		}
 
 		for name, dm := range delModels {


### PR DESCRIPTION
**- Summary**

When using a namespace we were not able to delete an instance because it would pick the wrong table name (without namespace).
This is caused by the non-pointer model not matching the `Tablenameable` interface.

**- Test plan**

Hot fix. Verified in staging.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://source.unsplash.com/6GMq7AGxNbE)