### PR TITLE
Add databse string example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ Chooses what dialect of database you want. Must be `mysql`.
 
 `DATABASE_URL` (no prefix) / `DB_DATABASE_URL` - `string` **required**
 
-Connection string for the database.
+Connection string for the database. 
+
+The connection string requires the following two parameters: `?parseTime=true&multiStatements=true`
+
+Eg: `mysql://user:pass@tcp(127.0.0.1:3306)/database?parseTime=true&multiStatements=true`
 
 `DB_NAMESPACE` - `string`
 


### PR DESCRIPTION
The DB url requires some extra parameters to work

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/gotrue/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

```sh
[POP] 2020/01/08 12:25:03 warn - IMPORTANT! 'parseTime=true' option is required to work properly. Please add it to the database URL in the config!
[POP] 2020/01/08 12:25:03 warn - IMPORTANT! 'multiStatements=true' option is required to work properly. Please add it to the database URL in the config!
```

Might as well describe this in the readme as it is a requirement to use the service.

**- Test plan**

Documentation only

**- Description for the changelog**

Added an example database URI

**- A picture of a cute animal (not mandatory but encouraged)**
