### PR TITLE
Hide smtp pass from instance config output

### DIFF
--- a/api/instance.go
+++ b/api/instance.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi"
+	"github.com/gobuffalo/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
 	"github.com/pkg/errors"
-	"github.com/gobuffalo/uuid"
 )
 
 func (a *API) loadInstance(w http.ResponseWriter, r *http.Request) (context.Context, error) {
@@ -89,6 +89,7 @@ func (a *API) CreateInstance(w http.ResponseWriter, r *http.Request) error {
 
 func (a *API) GetInstance(w http.ResponseWriter, r *http.Request) error {
 	i := getInstance(r.Context())
+	i.BaseConfig.SMTP.Pass = ""
 	return sendJSON(w, http.StatusOK, i)
 }
 

--- a/api/instance.go
+++ b/api/instance.go
@@ -89,7 +89,9 @@ func (a *API) CreateInstance(w http.ResponseWriter, r *http.Request) error {
 
 func (a *API) GetInstance(w http.ResponseWriter, r *http.Request) error {
 	i := getInstance(r.Context())
-	i.BaseConfig.SMTP.Pass = ""
+	if i.BaseConfig != nil {
+		i.BaseConfig.SMTP.Pass = ""
+	}
 	return sendJSON(w, http.StatusOK, i)
 }
 

--- a/api/instance.go
+++ b/api/instance.go
@@ -112,7 +112,11 @@ func (a *API) UpdateInstance(w http.ResponseWriter, r *http.Request) error {
 		if err := i.UpdateConfig(a.db, params.BaseConfig); err != nil {
 			return internalServerError("Database error updating instance").WithInternalError(err)
 		}
-		i.BaseConfig.SMTP.Pass = "" // hide from response
+	}
+
+	// Hide SMTP credential from response
+	if i.BaseConfig != nil {
+		i.BaseConfig.SMTP.Pass = ""
 	}
 	return sendJSON(w, http.StatusOK, i)
 }

--- a/api/instance.go
+++ b/api/instance.go
@@ -79,6 +79,11 @@ func (a *API) CreateInstance(w http.ResponseWriter, r *http.Request) error {
 		return internalServerError("Database error creating instance").WithInternalError(err)
 	}
 
+	// hide pass in response
+	if i.BaseConfig != nil {
+		i.BaseConfig.SMTP.Pass = ""
+	}
+
 	resp := InstanceResponse{
 		Instance: i,
 		Endpoint: a.config.API.Endpoint,
@@ -107,6 +112,7 @@ func (a *API) UpdateInstance(w http.ResponseWriter, r *http.Request) error {
 		if err := i.UpdateConfig(a.db, params.BaseConfig); err != nil {
 			return internalServerError("Database error updating instance").WithInternalError(err)
 		}
+		i.BaseConfig.SMTP.Pass = "" // hide from response
 	}
 	return sendJSON(w, http.StatusOK, i)
 }

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -90,7 +90,7 @@ type SMTPConfiguration struct {
 	Host         string        `json:"host"`
 	Port         int           `json:"port" default:"587"`
 	User         string        `json:"user"`
-	Pass         string        `json:"pass"`
+	Pass         string        `json:"pass,omitempty"`
 	AdminEmail   string        `json:"admin_email" split_words:"true"`
 }
 


### PR DESCRIPTION
**- Summary**

We do not want to show a once entered password when getting instance details.

**- Test plan**

- Tests pass

**- Description for the changelog**

Hide SMTP password from instance return

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://source.unsplash.com/rHmn-CYiMlo)