### PR TITLE
Docs: Fix logging env vars example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Adds a prefix to all table names.
 ### Logging
 
 ```
-GOTRUE_LOG_LEVEL=debug
+LOG_LEVEL=debug # available without GOTRUE prefix (exception)
 GOTRUE_LOG_FILE=/var/log/go/gotrue.log
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Adds a prefix to all table names.
 ### Logging
 
 ```
-LOG_LEVEL=debug
+GOTRUE_LOG_LEVEL=debug
+GOTRUE_LOG_FILE=/var/log/go/gotrue.log
 ```
 
 `LOG_LEVEL` - `string`


### PR DESCRIPTION
Add `GOTRUE_` prefix to prevent confusion, also add `GOTRUE_LOG_FILE` sample value.

> Should also add `GOTRUE_LOG_FILE` to _example.env_?

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/gotrue/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Minor doc fix because I've tried with `LOG_FILE` and it took me a few minutes to realize that the log was empty :disappointed: 
Then I tried with `GOTRUE_LOG_FILE` and it works :smile: 

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

docs(readme): fix logging env vars example

**- A picture of a cute animal (not mandatory but encouraged)**

![12670095_951550701593485_936418740864488038_n](https://user-images.githubusercontent.com/10326572/74207519-c3924000-4c5e-11ea-8433-740bb29d076e.jpg)
