### PR TITLE
Hide port field in config response if unset

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -88,7 +88,7 @@ type ProviderConfiguration struct {
 type SMTPConfiguration struct {
 	MaxFrequency time.Duration `json:"max_frequency" split_words:"true"`
 	Host         string        `json:"host"`
-	Port         int           `json:"port" default:"587"`
+	Port         int           `json:"port,omitempty" default:"587"`
 	User         string        `json:"user"`
 	Pass         string        `json:"pass,omitempty"`
 	AdminEmail   string        `json:"admin_email" split_words:"true"`


### PR DESCRIPTION
**- Summary**

To better work with default values in the frontend, we decided to omit this field when the default is used.

**- Test plan**

- Minor change, tests passing

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://source.unsplash.com/qQUtvVdurHg)