### PR TITLE
Document password field for /verify.

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,9 +352,12 @@ GoTrue exposes the following endpoints:
   ```json
   {
     "type": "signup",
-    "token": "confirmation-code-delivered-in-email"
+    "token": "confirmation-code-delivered-in-email",
+    "password": "12345abcdef"
   }
   ```
+  
+  `password` is required for signup verification if no existing password exists.
 
   Returns:
 


### PR DESCRIPTION
Include `password` field required for signup verification.

Fixes #239 

![Selection_193](https://user-images.githubusercontent.com/80635/79605529-17d1fa00-80be-11ea-89bf-43da1ca6d4ff.png)
