### PR TITLE
ci: run test action on PRs or pushes to master branch/tags

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,9 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+    tags: ['*']
+  pull_request:
+    types: [opened, synchronize, reopened]
 name: Test
 jobs:
   test:


### PR DESCRIPTION
https://github.com/netlify/gotrue/pull/240 migrated from Travis CI to GitHub actions, but as a result the test action is running twice for each open pull request, once for the push event and once for the PR event.
This fixes that.

You can see the duplicate actions in https://github.com/netlify/gotrue/pull/243:
![image](https://user-images.githubusercontent.com/26760571/79728676-f740b480-82f6-11ea-8e97-de34f025ddf5.png)
