### PR TITLE
fix(external-gitlab): don't override primary email with additional em…

### DIFF
--- a/api/external.go
+++ b/api/external.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/gobuffalo/uuid"
 	"github.com/netlify/gotrue/api/provider"
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage"
-	"github.com/gobuffalo/uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -114,7 +114,9 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 			}
 		} else {
 			aud := a.requestAud(ctx, r)
-			user, terr = models.FindUserByEmailAndAudience(tx, instanceID, userData.Email, aud)
+			if userData.Verified || config.Mailer.Autoconfirm {
+				user, terr = models.FindUserByEmailAndAudience(tx, instanceID, userData.Email, aud)
+			}
 			if terr != nil && !models.IsNotFoundError(terr) {
 				return internalServerError("Error checking for duplicate users").WithInternalError(terr)
 			}

--- a/api/external_test.go
+++ b/api/external_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/gobuffalo/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
-	"github.com/gobuffalo/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -166,10 +166,7 @@ func (ts *ExternalTestSuite) TestSignupExternalGitlab_AuthorizationCode() {
 		case "/api/v4/user":
 			userCount++
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprint(w, `{"name":"Gitlab Test","avatar_url":"http://example.com/avatar"}`)
-		case "/api/v4/user/emails":
-			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprint(w, `[{"email":"gitlab@example.com"}]`)
+			fmt.Fprint(w, `{"name":"Gitlab Test","email":"gitlab@example.com","avatar_url":"http://example.com/avatar","confirmed_at": "2020-01-01T00:00:00.000Z"}`)
 		default:
 			w.WriteHeader(500)
 			ts.Fail("unknown gitlab oauth call %s", r.URL.Path)

--- a/api/invite_test.go
+++ b/api/invite_test.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/gobuffalo/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
-	"github.com/gobuffalo/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -197,10 +197,7 @@ func (ts *InviteTestSuite) TestInviteExternalGitlab() {
 		case "/api/v4/user":
 			userCount++
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprint(w, `{"name":"Gitlab Test","avatar_url":"http://example.com/avatar"}`)
-		case "/api/v4/user/emails":
-			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprint(w, `[{"email":"gitlab@example.com"}]`)
+			fmt.Fprint(w, `{"name":"Gitlab Test","email":"gitlab@example.com","avatar_url":"http://example.com/avatar","confirmed_at": "2020-01-01T00:00:00.000Z"}`)
 		default:
 			w.WriteHeader(http.StatusInternalServerError)
 			ts.Fail("unknown gitlab oauth call %s", r.URL.Path)
@@ -288,10 +285,7 @@ func (ts *InviteTestSuite) TestInviteExternalGitlab_MismatchedEmails() {
 		case "/api/v4/user":
 			userCount++
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprint(w, `{"name":"Gitlab Test","avatar_url":"http://example.com/avatar"}`)
-		case "/api/v4/user/emails":
-			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprint(w, `[{"email":"gitlab+mismatch@example.com"}]`)
+			fmt.Fprint(w, `{"name":"Gitlab Test","email":"gitlab+mismatch@example.com","avatar_url":"http://example.com/avatar","confirmed_at": "2020-01-01T00:00:00.000Z"}`)
 		default:
 			w.WriteHeader(500)
 			ts.Fail("unknown gitlab oauth call %s", r.URL.Path)


### PR DESCRIPTION
Fixes https://github.com/netlify/gotrue/issues/249

Removed getting additional emails for GitLab all together until we support multiple emails per provider (https://github.com/netlify/gotrue/pull/243) 