### PR TITLE
chore: docker releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - chore/docker_releases
+      - master
 
 jobs:
   release:
@@ -18,7 +18,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: supabase/gotrue
-          tags: nightly
+          repository: ${{ secrets.DOCKER_REPO }}
+          tags: dev
 
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Upload image to Docker Hub
-        if: env.HAS_NEW_RELEASE == 1
         uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - chore/docker_releases
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Upload image to Docker Hub
+        if: env.HAS_NEW_RELEASE == 1
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: supabase/gotrue
+          tags: nightly
+
+          


### PR DESCRIPTION
**- Summary**

Adds an automated docker release on every push to `master`. Closes #179 

**- Test plan**

Add secrets (see below), commit to `master`, check docker hub.

**- Description for the changelog**

This change adds an action to release to docker hub every time there is a commit to the master branch. This is a small improvement - it simply adds a docker image with the tag `dev` (i.e: `netlify/gotrue:dev`). I chose this tagging so there isn't any ambiguity of production support, but it makes it easy for contributors and developers to get started using gotrue

It requires 3 secrets to be added here: https://github.com/netlify/gotrue/settings/secrets

```sh
DOCKER_REPO              # netlify/gotrue
DOCKER_USERNAME    # someone with access
DOCKER_PASSWORD    # the user's password
```