### PR TITLE
Merge instance update params with existing instance

### DIFF
--- a/api/instance.go
+++ b/api/instance.go
@@ -103,7 +103,7 @@ func (a *API) GetInstance(w http.ResponseWriter, r *http.Request) error {
 func (a *API) UpdateInstance(w http.ResponseWriter, r *http.Request) error {
 	i := getInstance(r.Context())
 
-	params := InstanceRequestParams{}
+	params := InstanceRequestParams{BaseConfig: i.BaseConfig}
 	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
 		return badRequestError("Error decoding params: %v", err)
 	}

--- a/api/instance.go
+++ b/api/instance.go
@@ -108,10 +108,8 @@ func (a *API) UpdateInstance(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Error decoding params: %v", err)
 	}
 
-	if params.BaseConfig != nil {
-		if err := i.UpdateConfig(a.db, params.BaseConfig); err != nil {
-			return internalServerError("Database error updating instance").WithInternalError(err)
-		}
+	if err := i.UpdateConfig(a.db, params.BaseConfig); err != nil {
+		return internalServerError("Database error updating instance").WithInternalError(err)
 	}
 
 	// Hide SMTP credential from response

--- a/api/instance_test.go
+++ b/api/instance_test.go
@@ -174,3 +174,79 @@ func (ts *InstanceTestSuite) TestUpdate_DisableEmail() {
 	require.NoError(ts.T(), err)
 	require.True(ts.T(), i.BaseConfig.External.Email.Disabled)
 }
+
+func (ts *InstanceTestSuite) TestUpdate_PreserveSMTPConfig() {
+	instanceID := uuid.Must(uuid.NewV4())
+	err := ts.API.db.Create(&models.Instance{
+		ID:   instanceID,
+		UUID: testUUID,
+		BaseConfig: &conf.Configuration{
+			SMTP: conf.SMTPConfiguration{
+				Host: "foo.com",
+				User: "Admin",
+				Pass: "password123",
+			},
+		},
+	})
+	require.NoError(ts.T(), err)
+
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"config": &conf.Configuration{
+			Mailer: conf.MailerConfiguration{
+				Subjects:  conf.EmailContentConfiguration{Invite: "foo"},
+				Templates: conf.EmailContentConfiguration{Invite: "bar"},
+			},
+		},
+	}))
+
+	req := httptest.NewRequest(http.MethodPut, "/instances/"+instanceID.String(), &buffer)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+operatorToken)
+
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	require.Equal(ts.T(), w.Code, http.StatusOK)
+
+	i, err := models.GetInstanceByUUID(ts.API.db, testUUID)
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), "password123", i.BaseConfig.SMTP.Pass)
+}
+
+func (ts *InstanceTestSuite) TestUpdate_ClearPassword() {
+	instanceID := uuid.Must(uuid.NewV4())
+	err := ts.API.db.Create(&models.Instance{
+		ID:   instanceID,
+		UUID: testUUID,
+		BaseConfig: &conf.Configuration{
+			SMTP: conf.SMTPConfiguration{
+				Host: "foo.com",
+				User: "Admin",
+				Pass: "password123",
+			},
+		},
+	})
+	require.NoError(ts.T(), err)
+
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"config": map[string]interface{}{
+			"smtp": map[string]interface{}{
+				"pass": "",
+			},
+		},
+	}))
+	ts.T().Log(buffer.String())
+
+	req := httptest.NewRequest(http.MethodPut, "/instances/"+instanceID.String(), &buffer)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+operatorToken)
+
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	require.Equal(ts.T(), w.Code, http.StatusOK)
+
+	i, err := models.GetInstanceByUUID(ts.API.db, testUUID)
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), "", i.BaseConfig.SMTP.Pass)
+}

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -95,17 +95,19 @@ type SMTPConfiguration struct {
 	AdminEmail   string        `json:"admin_email" split_words:"true"`
 }
 
+type MailerConfiguration struct {
+	Autoconfirm bool                      `json:"autoconfirm"`
+	Subjects    EmailContentConfiguration `json:"subjects"`
+	Templates   EmailContentConfiguration `json:"templates"`
+	URLPaths    EmailContentConfiguration `json:"url_paths"`
+}
+
 // Configuration holds all the per-instance configuration.
 type Configuration struct {
-	SiteURL string            `json:"site_url" split_words:"true" required:"true"`
-	JWT     JWTConfiguration  `json:"jwt"`
-	SMTP    SMTPConfiguration `json:"smtp"`
-	Mailer  struct {
-		Autoconfirm bool                      `json:"autoconfirm"`
-		Subjects    EmailContentConfiguration `json:"subjects"`
-		Templates   EmailContentConfiguration `json:"templates"`
-		URLPaths    EmailContentConfiguration `json:"url_paths"`
-	} `json:"mailer"`
+	SiteURL       string                `json:"site_url" split_words:"true" required:"true"`
+	JWT           JWTConfiguration      `json:"jwt"`
+	SMTP          SMTPConfiguration     `json:"smtp"`
+	Mailer        MailerConfiguration   `json:"mailer"`
 	External      ProviderConfiguration `json:"external"`
 	DisableSignup bool                  `json:"disable_signup" split_words:"true"`
 	Webhook       WebhookConfig         `json:"webhook" split_words:"true"`


### PR DESCRIPTION
**- Summary**
When we update an Identity instance from Netlify's API, we first get the identity instance from gotrue, then merge in any updates, and finally send the merged instance back to gotrue to replace the original.

This is problematic because gotrue no longer serializes the instance's SMTP password field (https://github.com/netlify/gotrue/pull/227).

This PR changes the instance update handler to merge the existing instance configuration with the request parameters. Fields can be explicitly unset by including the field's zero value (eg an empty string) in the json request body instead of omitting the key.

**- Test plan**
Added test that show
* updating other fields on the `Instance` doesn't erase the password
* password can be erased by passing `password: ""` in the request body

**- Description for the changelog**
Allow partial update of Instance fields in the Instance update handler.

**- A picture of a cute animal (not mandatory but encouraged)**
![snowcat](https://user-images.githubusercontent.com/1887071/90580722-68498900-e17e-11ea-82f5-e55db774ffbf.jpg)
