### PR TITLE
Support multiple function hooks per event

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/gobuffalo/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
-	"github.com/gobuffalo/uuid"
 )
 
 type contextKey string
@@ -196,18 +196,18 @@ func getExternalReferrer(ctx context.Context) string {
 }
 
 // withFunctionHooks adds the provided function hooks to the context.
-func withFunctionHooks(ctx context.Context, hooks map[string]string) context.Context {
+func withFunctionHooks(ctx context.Context, hooks map[string][]string) context.Context {
 	return context.WithValue(ctx, functionHooksKey, hooks)
 }
 
 // getFunctionHooks reads the request ID from the context.
-func getFunctionHooks(ctx context.Context) map[string]string {
+func getFunctionHooks(ctx context.Context) map[string][]string {
 	obj := ctx.Value(functionHooksKey)
 	if obj == nil {
-		return map[string]string{}
+		return map[string][]string{}
 	}
 
-	return obj.(map[string]string)
+	return obj.(map[string][]string)
 }
 
 // withAdminUser adds the admin user to the context.

--- a/api/external.go
+++ b/api/external.go
@@ -177,7 +177,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 				if terr := models.NewAuditLogEntry(tx, instanceID, user, models.UserSignedUpAction, nil); terr != nil {
 					return terr
 				}
-				if terr = triggerHook(ctx, tx, SignupEvent, user, instanceID, config); terr != nil {
+				if terr = triggerEventHooks(ctx, tx, SignupEvent, user, instanceID, config); terr != nil {
 					return terr
 				}
 
@@ -189,7 +189,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 				if terr := models.NewAuditLogEntry(tx, instanceID, user, models.LoginAction, nil); terr != nil {
 					return terr
 				}
-				if terr = triggerHook(ctx, tx, LoginEvent, user, instanceID, config); terr != nil {
+				if terr = triggerEventHooks(ctx, tx, LoginEvent, user, instanceID, config); terr != nil {
 					return terr
 				}
 			}
@@ -261,7 +261,7 @@ func (a *API) processInvite(ctx context.Context, tx *storage.Connection, userDat
 	if err := models.NewAuditLogEntry(tx, instanceID, user, models.InviteAcceptedAction, nil); err != nil {
 		return nil, err
 	}
-	if err := triggerHook(ctx, tx, SignupEvent, user, instanceID, config); err != nil {
+	if err := triggerEventHooks(ctx, tx, SignupEvent, user, instanceID, config); err != nil {
 		return nil, err
 	}
 

--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -55,7 +55,7 @@ func TestSignupHookSendInstanceID(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, triggerHook(context.Background(), conn, SignupEvent, user, iid, config))
+	require.NoError(t, triggerEventHooks(context.Background(), conn, SignupEvent, user, iid, config))
 
 	assert.Equal(t, 1, callCount)
 }
@@ -102,7 +102,7 @@ func TestSignupHookFromClaims(t *testing.T) {
 		"signup": []string{svr.URL},
 	})
 
-	require.NoError(t, triggerHook(ctx, conn, SignupEvent, user, iid, config))
+	require.NoError(t, triggerEventHooks(ctx, conn, SignupEvent, user, iid, config))
 
 	assert.Equal(t, 1, callCount)
 }

--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -98,8 +98,8 @@ func TestSignupHookFromClaims(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ctx = withFunctionHooks(ctx, map[string]string{
-		"signup": svr.URL,
+	ctx = withFunctionHooks(ctx, map[string][]string{
+		"signup": []string{svr.URL},
 	})
 
 	require.NoError(t, triggerHook(ctx, conn, SignupEvent, user, iid, config))

--- a/api/hooks.go
+++ b/api/hooks.go
@@ -174,7 +174,7 @@ func triggerHook(ctx context.Context, conn *storage.Connection, event HookEvent,
 
 		if eventHookURL, ok := fun[string(event)]; ok {
 			var err error
-			hookURL, err = url.Parse(eventHookURL)
+			hookURL, err = url.Parse(eventHookURL[0])
 			if err != nil {
 				return errors.Wrapf(err, "Failed to parse Event Function Hook URL")
 			}

--- a/api/hooks.go
+++ b/api/hooks.go
@@ -152,39 +152,37 @@ func closeBody(rsp *http.Response) {
 	}
 }
 
-func triggerHook(ctx context.Context, conn *storage.Connection, event HookEvent, user *models.User, instanceID uuid.UUID, config *conf.Configuration) error {
-	var hookURL *url.URL
-	secret := config.Webhook.Secret
+func triggerEventHooks(ctx context.Context, conn *storage.Connection, event HookEvent, user *models.User, instanceID uuid.UUID, config *conf.Configuration) error {
 	if config.Webhook.URL != "" {
-		var err error
-		hookURL, err = url.Parse(config.Webhook.URL)
+		hookURL, err := url.Parse(config.Webhook.URL)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to parse Webhook URL")
 		}
 		if !config.Webhook.HasEvent(string(event)) {
 			return nil
 		}
+		return triggerHook(ctx, hookURL, config.Webhook.Secret, conn, event, user, instanceID, config)
 	}
 
-	if hookURL == nil {
-		fun := getFunctionHooks(ctx)
-		if fun == nil {
-			return nil
-		}
-
-		if eventHookURL, ok := fun[string(event)]; ok {
-			var err error
-			hookURL, err = url.Parse(eventHookURL[0])
-			if err != nil {
-				return errors.Wrapf(err, "Failed to parse Event Function Hook URL")
-			}
-			secret = config.JWT.Secret
-		} else {
-			// abort hook call if there are no functions for this event
-			return nil
-		}
+	fun := getFunctionHooks(ctx)
+	if fun == nil {
+		return nil
 	}
 
+	for _, eventHookURL := range fun[string(event)] {
+		hookURL, err := url.Parse(eventHookURL)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to parse Event Function Hook URL")
+		}
+		err = triggerHook(ctx, hookURL, config.JWT.Secret, conn, event, user, instanceID, config)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func triggerHook(ctx context.Context, hookURL *url.URL, secret string, conn *storage.Connection, event HookEvent, user *models.User, instanceID uuid.UUID, config *conf.Configuration) error {
 	if !hookURL.IsAbs() {
 		siteURL, err := url.Parse(config.SiteURL)
 		if err != nil {

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -18,12 +19,37 @@ const (
 	jwsSignatureHeaderName = "x-nf-sign"
 )
 
+type FunctionHooks map[string][]string
+
 type NetlifyMicroserviceClaims struct {
 	jwt.StandardClaims
-	SiteURL       string            `json:"site_url"`
-	InstanceID    string            `json:"id"`
-	NetlifyID     string            `json:"netlify_id"`
-	FunctionHooks map[string]string `json:"function_hooks"`
+	SiteURL       string        `json:"site_url"`
+	InstanceID    string        `json:"id"`
+	NetlifyID     string        `json:"netlify_id"`
+	FunctionHooks FunctionHooks `json:"function_hooks"`
+}
+
+func (f FunctionHooks) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	err := json.Unmarshal(b, &raw)
+	if err != nil {
+		return err
+	}
+
+	if f == nil {
+		f = make(map[string][]string)
+	}
+
+	for event, i := range raw {
+		switch val := i.(type) {
+		case []string:
+			f[event] = val
+		case string:
+			// Support legacy format for function hooks json.
+			f[event] = []string{val}
+		}
+	}
+	return nil
 }
 
 func addGetBody(w http.ResponseWriter, req *http.Request) (context.Context, error) {

--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFunctionHooksUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		in string
+		ok bool
+	}{
+		{`{ "signup" : "identity-signup" }`, true},
+		{`{ "signup" : ["identity-signup"] }`, true},
+		{`{ "signup" : {"foo" : "bar"} }`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			var f FunctionHooks
+			err := json.Unmarshal([]byte(tt.in), &f)
+			if tt.ok {
+				assert.NoError(t, err)
+				assert.Equal(t, FunctionHooks{"signup": {"identity-signup"}}, f)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}

--- a/api/signup.go
+++ b/api/signup.go
@@ -70,7 +70,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 			if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserSignedUpAction, nil); terr != nil {
 				return terr
 			}
-			if terr = triggerHook(ctx, tx, SignupEvent, user, instanceID, config); terr != nil {
+			if terr = triggerEventHooks(ctx, tx, SignupEvent, user, instanceID, config); terr != nil {
 				return terr
 			}
 			if terr = user.Confirm(tx); terr != nil {
@@ -117,7 +117,7 @@ func (a *API) signupNewUser(ctx context.Context, conn *storage.Connection, param
 		if terr := user.SetRole(tx, config.JWT.DefaultGroupName); terr != nil {
 			return internalServerError("Database error updating user").WithInternalError(terr)
 		}
-		if terr := triggerHook(ctx, tx, ValidateEvent, user, instanceID, config); terr != nil {
+		if terr := triggerEventHooks(ctx, tx, ValidateEvent, user, instanceID, config); terr != nil {
 			return terr
 		}
 		return nil

--- a/api/token.go
+++ b/api/token.go
@@ -78,7 +78,7 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 		if terr = models.NewAuditLogEntry(tx, instanceID, user, models.LoginAction, nil); terr != nil {
 			return terr
 		}
-		if terr = triggerHook(ctx, tx, LoginEvent, user, instanceID, config); terr != nil {
+		if terr = triggerEventHooks(ctx, tx, LoginEvent, user, instanceID, config); terr != nil {
 			return terr
 		}
 

--- a/api/verify.go
+++ b/api/verify.go
@@ -106,7 +106,7 @@ func (a *API) signupVerify(ctx context.Context, conn *storage.Connection, params
 			return terr
 		}
 
-		if terr = triggerHook(ctx, tx, SignupEvent, user, instanceID, config); terr != nil {
+		if terr = triggerEventHooks(ctx, tx, SignupEvent, user, instanceID, config); terr != nil {
 			return terr
 		}
 
@@ -142,7 +142,7 @@ func (a *API) recoverVerify(ctx context.Context, conn *storage.Connection, param
 				return terr
 			}
 
-			if terr = triggerHook(ctx, tx, SignupEvent, user, instanceID, config); terr != nil {
+			if terr = triggerEventHooks(ctx, tx, SignupEvent, user, instanceID, config); terr != nil {
 				return terr
 			}
 			if terr = user.Confirm(tx); terr != nil {


### PR DESCRIPTION
**- Summary**
Netlify supports automatically triggering Netlify Functions called `identity-validate`, `identity-signup`, and`identity-login` when those events occur in Gotrue. We could also like to support background functions, eg `identity-validate-background`. That means there can be multiple functions that should be triggered for each event. This PR updates Gotrue to support a list of functions that should be triggered when each event occurs.

GoTrue currently gets function hooks in the following form:
```json
"function_hooks" : {
  "signup": "identity-signup"
}
```

This PR additionally supports this form:
```json
"function_hooks" : {
  "signup": ["identity-signup", "identity-signup-background"]
}
```

Reviewing this PR by commit may be helpful.

**- Test plan**
Going to run some tests in staging tomorrow, will update here with details.
* Test that function hooks of the form `identity-validate` etc. still work
* Test that webhooks from instance configuration still work
* Function hooks like `identity-validate-background` will require additional changes to other services.

**- Description for the changelog**
Support triggering multiple function hooks per event.

**- A picture of a cute animal (not mandatory but encouraged)**
![tiger](https://user-images.githubusercontent.com/1887071/97117627-2f6bea00-16c2-11eb-82db-7aa61f6a249d.jpeg)
