### PR TITLE
Update test GH action to use setup-go@v2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2-beta
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code


### PR DESCRIPTION
**- Summary**

Noticed that tests is failing with https://github.com/netlify/gotrue/pull/267 due to the beta version usage of setup-go.
Updating.

**- Test plan**

Tests should go well.

**- Description for the changelog**

Update GH Action's setup-go version

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/911433/99924364-5d098900-2d7d-11eb-8644-f75bef04ce92.png)
