### PR TITLE
Set status code as string on spans

### DIFF
--- a/api/tracer_test.go
+++ b/api/tracer_test.go
@@ -51,13 +51,13 @@ func (ts *TracerTestSuite) TestTracer_Spans() {
 		assert.Equal(ts.T(), "POST", spans[0].Tag("http.method"))
 		assert.Equal(ts.T(), "/something1", spans[0].Tag("http.url"))
 		assert.Equal(ts.T(), "POST /something1", spans[0].Tag("resource.name"))
-		assert.Equal(ts.T(), uint16(http.StatusNotFound), spans[0].Tag("http.status_code"))
+		assert.Equal(ts.T(), "404", spans[0].Tag("http.status_code"))
 		assert.NotEmpty(ts.T(), spans[0].Tag("http.request_id"))
 
 		assert.Equal(ts.T(), "GET", spans[1].Tag("http.method"))
 		assert.Equal(ts.T(), "/something2", spans[1].Tag("http.url"))
 		assert.Equal(ts.T(), "GET /something2", spans[1].Tag("resource.name"))
-		assert.Equal(ts.T(), uint16(http.StatusNotFound), spans[1].Tag("http.status_code"))
+		assert.Equal(ts.T(), "404", spans[1].Tag("http.status_code"))
 		assert.NotEmpty(ts.T(), spans[1].Tag("http.request_id"))
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/gotrue/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
For whatever reason, in order to use the `http.status` tag of a trace span from a datadog dashboard, the status must be written as a string,  not an integer.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
Deploy to staging and verify we can see metrics on status codes in our datadog dashboard.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
Bug fix for span status codes in datadog dashboards.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
