### PR TITLE
feat: derive admin email from template

### DIFF
--- a/mailer/mailer_test.go
+++ b/mailer/mailer_test.go
@@ -3,6 +3,7 @@ package mailer
 import (
 	"testing"
 
+	"github.com/netlify/gotrue/conf"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,4 +46,13 @@ func TestRelativeURL(t *testing.T) {
 		res := enforceRelativeURL(c.URL)
 		assert.Equal(t, c.Expected, res, c.URL)
 	}
+}
+
+func TestGetEmailFrom(t *testing.T) {
+	res := getEmailFrom(&conf.Configuration{
+		SMTP: conf.SMTPConfiguration{
+			AdminEmail: "gotrue+{{.SiteID}}@example.com",
+		},
+	})
+	assert.Equal(t, "gotrue+something@example.com", res)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/gotrue/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

This PR makes the `SMTP_ADMIN_EMAIL` variable template-able, so one could e.g. implement `gotrue+{{siteId}}@example.com`.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

Added a unit test.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
