### PR TITLE
Fix reading webhook response when content length is unknown

### DIFF
--- a/api/hooks.go
+++ b/api/hooks.go
@@ -117,14 +117,15 @@ func (w *Webhook) trigger() (io.ReadCloser, error) {
 		}
 		dur := time.Since(start)
 		rspLog := hooklog.WithFields(logrus.Fields{
-			"status_code": rsp.StatusCode,
-			"dur":         dur.Nanoseconds(),
+			"status_code":    rsp.StatusCode,
+			"dur":            dur.Nanoseconds(),
+			"content_length": rsp.ContentLength,
 		})
 		switch rsp.StatusCode {
 		case http.StatusOK, http.StatusNoContent, http.StatusAccepted:
-			rspLog.Infof("Finished processing webhook in %s", dur)
+			rspLog.Info("Finished processing webhook")
 			var body io.ReadCloser
-			if rsp.ContentLength > 0 {
+			if rsp.Body != http.NoBody && rsp.ContentLength != 0 {
 				body = rsp.Body
 			}
 			return body, nil


### PR DESCRIPTION
**- Summary**

For https://github.com/netlify/pillar-runtime/issues/723

**- Test plan**

- Added a test
- Unable to test this on staging since targeting our staging instance is very tricky currently (fix in https://github.com/netlify/netlify-server/pull/2857)

**- Description for the changelog**

Fix reading webhook response when content length is unknown

**- A picture of a cute animal (not mandatory but encouraged)**
