### PR TITLE
Fix trigger response handling for streamed 0 length response body

### DIFF
--- a/api/hooks.go
+++ b/api/hooks.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptrace"
@@ -239,8 +240,20 @@ func triggerHook(ctx context.Context, hookURL *url.URL, secret string, conn *sto
 		}
 	}()
 	if err == nil && body != nil {
+		// handle case where response from the trigger is streamed but has no
+		// Body
+		data, err := ioutil.ReadAll(body)
+		if err != nil {
+			return internalServerError("Webhook returned malformed BODY: %v", err).WithInternalError(err)
+		}
+
+		if len(data) == 0 {
+			return nil
+		}
+
+		bodyReader := bytes.NewReader(data)
 		webhookRsp := &WebhookResponse{}
-		decoder := json.NewDecoder(body)
+		decoder := json.NewDecoder(bodyReader)
 		if err = decoder.Decode(webhookRsp); err != nil {
 			return internalServerError("Webhook returned malformed JSON: %v", err).WithInternalError(err)
 		}

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -131,13 +130,6 @@ func (ts *SignupTestSuite) TestWebhookTriggered() {
 
 		w.WriteHeader(http.StatusOK)
 		w.(http.Flusher).Flush() // needed so we don't set a content-length
-
-		pl := `{
-			"app_metadata": {
-				"roles": ["dev"]
-			}
-		}`
-		fmt.Fprint(w, pl)
 	}))
 	defer svr.Close()
 
@@ -168,10 +160,8 @@ func (ts *SignupTestSuite) TestWebhookTriggered() {
 	assert.Equal(http.StatusOK, w.Code)
 	assert.Equal(1, callCount)
 
-	var user models.User
-	require.NoError(json.NewDecoder(w.Body).Decode(&user))
-
-	assert.EqualValues(models.JSONMap{"roles": []interface{}{"dev"}}, user.AppMetaData)
+	// http stdlib doesn't set Body as http.NoBody if Content-Length = -1
+	require.True(w.Result().Body != http.NoBody)
 }
 
 func (ts *SignupTestSuite) TestFailingWebhook() {


### PR DESCRIPTION
For https://github.com/netlify/pillar-support/issues/395

**- Summary**

When the response is streamed (Content-Length == -1) but the body doesn't have any content, we fail hard when decoding the payload. This fixes that.

**- Test plan**

- Added a test

**- Description for the changelog**

Fix reading webhook response when content length is unknown and body is empty
