### PR TITLE
fix: revert JWT claims to StandardClaims to serialize aud as string

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -62,13 +62,7 @@ func getUserFromClaims(ctx context.Context, conn *storage.Connection) (*models.U
 	instanceID := getInstanceID(ctx)
 
 	if claims.Subject == models.SystemUserUUID.String() || claims.Subject == models.SystemUserID {
-		// Even though claims.Audience might include multiple audiences,
-		// GoTrue has always only supported single-audience tokens.
-		aud := ""
-		if len(claims.Audience) > 0 {
-			aud = claims.Audience[0]
-		}
-		return models.NewSystemUser(instanceID, aud), nil
+		return models.NewSystemUser(instanceID, claims.Audience), nil
 	}
 	userID, err := uuid.FromString(claims.Subject)
 	if err != nil {
@@ -93,11 +87,9 @@ func (a *API) requestAud(ctx context.Context, r *http.Request) string {
 	}
 
 	// Then check the token
-	// Even though claims.Audience might include multiple audiences,
-	// GoTrue has always only supported single-audience tokens.
 	claims := getClaims(ctx)
-	if claims != nil && len(claims.Audience) > 0 {
-		return claims.Audience[0]
+	if claims != nil && claims.Audience != "" {
+		return claims.Audience
 	}
 
 	// Finally, return the default of none of the above methods are successful

--- a/api/token.go
+++ b/api/token.go
@@ -13,11 +13,15 @@ import (
 )
 
 // GoTrueClaims is a struct thats used for JWT claims
+// TODO: migrate from jwt.StandardClaims to jwt.RegisteredClaims. RegisteredClaims
+// serializes "aud" as a JSON array, but Git Gateway (and other consumers) expect a
+// string. A custom MarshalJSON/UnmarshalJSON on GoTrueClaims is needed to handle both
+// formats before switching.
 type GoTrueClaims struct {
-	jwt.RegisteredClaims
-	Email        string                 `json:"email"`
-	AppMetaData  map[string]interface{} `json:"app_metadata"`
-	UserMetaData map[string]interface{} `json:"user_metadata"`
+	jwt.StandardClaims                        //nolint:staticcheck // RegisteredClaims serializes aud as array, breaking Git Gateway
+	Email              string                 `json:"email"`
+	AppMetaData        map[string]interface{} `json:"app_metadata"`
+	UserMetaData       map[string]interface{} `json:"user_metadata"`
 }
 
 // AccessTokenResponse represents an OAuth2 success response
@@ -165,10 +169,10 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 
 func generateAccessToken(user *models.User, expiresIn time.Duration, secret string) (string, error) {
 	claims := &GoTrueClaims{
-		RegisteredClaims: jwt.RegisteredClaims{
+		StandardClaims: jwt.StandardClaims{ //nolint:staticcheck
 			Subject:   user.ID.String(),
-			Audience:  jwt.ClaimStrings{user.Aud},
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(expiresIn)),
+			Audience:  user.Aud,
+			ExpiresAt: time.Now().Add(expiresIn).Unix(),
 		},
 		Email:        user.Email,
 		AppMetaData:  user.AppMetaData,

--- a/api/user.go
+++ b/api/user.go
@@ -31,10 +31,8 @@ func (a *API) UserGet(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Could not read User ID claim")
 	}
 
-	// Even though claims.Audience might include multiple audiences,
-	// GoTrue has always only supported single-audience tokens.
 	aud := a.requestAud(ctx, r)
-	if len(claims.Audience) == 0 || aud != claims.Audience[0] {
+	if aud != claims.Audience {
 		return badRequestError("Token audience doesn't match request audience")
 	}
 


### PR DESCRIPTION
This reverts JWT claims to `StandardClaim`s to serialize aud as string. `RegisteredClaims` (introduced in [14dd327](https://github.com/netlify/gotrue/pull/387/changes)) serializes the aud claim as a JSON array, but Git Gateway expects a string and fails with a 401.

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/gotrue/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
<img width="320" height="322" alt="image" src="https://github.com/user-attachments/assets/3639e14c-3727-4229-8496-7dac7ac4dd82" />

