### PR TITLE
fix: expire recovery tokens after 24h

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -98,10 +98,11 @@ type SMTPConfiguration struct {
 }
 
 type MailerConfiguration struct {
-	Autoconfirm bool                      `json:"autoconfirm"`
-	Subjects    EmailContentConfiguration `json:"subjects"`
-	Templates   EmailContentConfiguration `json:"templates"`
-	URLPaths    EmailContentConfiguration `json:"url_paths"`
+	Autoconfirm    bool                      `json:"autoconfirm"`
+	Subjects       EmailContentConfiguration `json:"subjects"`
+	Templates      EmailContentConfiguration `json:"templates"`
+	URLPaths       EmailContentConfiguration `json:"url_paths"`
+	RecoveryMaxAge time.Duration             `json:"recovery_max_age" split_words:"true"`
 }
 
 // Configuration holds all the per-instance configuration.
@@ -212,6 +213,10 @@ func (config *Configuration) ApplyDefaults() {
 
 	if config.SMTP.MaxFrequency == 0 {
 		config.SMTP.MaxFrequency = 15 * time.Minute
+	}
+
+	if config.Mailer.RecoveryMaxAge == 0 {
+		config.Mailer.RecoveryMaxAge = 24 * time.Hour
 	}
 
 	if config.Cookie.Key == "" {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/gotrue/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

- `recoverVerify` only checks that the recovery token exists, it never checks `recovery_sent_at`. Tokens are valid indefinitely until consumed or overwritten.
- Adds a `RecoveryMaxAge` config to `MailerConfiguration` (default 24h, env `GOTRUE_MAILER_RECOVERY_MAX_AGE`) and checks token age in `recoverVerify` before consuming it. Returns 422 if expired.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
