### PR TITLE
fix: forward function hooks in OAuth state JWT for identity events

### DIFF
--- a/api/external.go
+++ b/api/external.go
@@ -60,9 +60,10 @@ func (a *API) ExternalProviderRedirect(w http.ResponseWriter, r *http.Request) e
 			RegisteredClaims: jwt.RegisteredClaims{
 				ExpiresAt: jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 			},
-			SiteURL:    config.SiteURL,
-			InstanceID: getInstanceID(ctx).String(),
-			NetlifyID:  getNetlifyID(ctx),
+			SiteURL:       config.SiteURL,
+			InstanceID:    getInstanceID(ctx).String(),
+			NetlifyID:     getNetlifyID(ctx),
+			FunctionHooks: getFunctionHooks(ctx),
 		},
 		Provider:    providerType,
 		InviteToken: inviteToken,


### PR DESCRIPTION
## Summary

- Forward `FunctionHooks` in the OAuth state JWT so identity events (`identity-signup`, `identity-login`, `identity-validate`) fire during OAuth provider flows (GitHub, Google, etc.)
- Add test verifying function hooks survive the OAuth redirect round-trip

## Context

Resolves [EX-1607](https://linear.app/netlify/issue/EX-1607)

In multi-instance mode, function hook URLs are passed to GoTrue via the `x-nf-sign` JWT header. The middleware chain for email endpoints correctly extracts and forwards these hooks. For OAuth, the flow breaks because `ExternalProviderRedirect` creates a state JWT that omits `FunctionHooks`. After the OAuth provider redirects back to `/callback`, `loadOAuthState` restores context from that state JWT — but hooks are missing, so `triggerEventHooks` finds nothing to fire.

The fix adds `FunctionHooks: getFunctionHooks(ctx)` to the state JWT, matching the existing pattern for `SiteURL`, `InstanceID`, and `NetlifyID`.

## Test plan

- [ ] Existing tests pass (`go test ./api/ -run TestExternal`)
- [ ] New `TestSignupExternalGithubForwardsFunctionHooks` verifies hooks appear in the state JWT
- [ ] Manual: OAuth signup with identity functions configured triggers `identity-signup`