### PR TITLE
feat: add rate limiting to /invite endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -127,7 +127,12 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 
 		r.Get("/authorize", api.ExternalProviderRedirect)
 
-		r.With(api.requireAdminCredentials).Post("/invite", api.Invite)
+		r.With(api.requireAdminCredentials).With(api.limitHandler(
+			// Allow requests at a rate of 10 per minute.
+			tollbooth.NewLimiter(10.0/60, &limiter.ExpirableOptions{
+				DefaultExpirationTTL: time.Hour,
+			}).SetBurst(10),
+		)).Post("/invite", api.Invite)
 
 		r.With(api.requireEmailProvider).Post("/signup", api.Signup)
 		r.With(api.requireEmailProvider).Post("/recover", api.Recover)

--- a/api/invite_test.go
+++ b/api/invite_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 	"time"
 
@@ -29,6 +30,7 @@ type InviteTestSuite struct {
 }
 
 func TestInvite(t *testing.T) {
+	os.Setenv("GOTRUE_RATE_LIMIT_HEADER", "My-Custom-Header")
 	api, config, instanceID, err := setupAPIForTestForInstance()
 	require.NoError(t, err)
 
@@ -147,6 +149,38 @@ func (ts *InviteTestSuite) TestVerifyInvite() {
 	ts.API.handler.ServeHTTP(w, req)
 
 	assert.Equal(ts.T(), http.StatusOK, w.Code, w.Body.String())
+}
+
+func (ts *InviteTestSuite) TestInviteRateLimit() {
+	for i := 0; i < 10; i++ {
+		var buffer bytes.Buffer
+		require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+			"email": fmt.Sprintf("test%d@example.com", i),
+		}))
+
+		req := httptest.NewRequest(http.MethodPost, "http://localhost/invite", &buffer)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", ts.token))
+		req.Header.Set("My-Custom-Header", "1.2.3.4") // add this
+
+		w := httptest.NewRecorder()
+		ts.API.handler.ServeHTTP(w, req)
+		assert.Equal(ts.T(), http.StatusOK, w.Code)
+	}
+
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"email": "ratelimited@example.com",
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/invite", &buffer)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", ts.token))
+	req.Header.Set("My-Custom-Header", "1.2.3.4") // add this
+
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	assert.Equal(ts.T(), http.StatusTooManyRequests, w.Code)
 }
 
 func (ts *InviteTestSuite) TestVerifyInvite_NoPassword() {


### PR DESCRIPTION
**- Summary**
The `/invite` endpoint had no rate limiting despite being an email-sending
endpoint protected by `requireAdminCredentials`. A compromised admin token
could be used to send bulk invite emails with no throttling. This PR wires
a tollbooth limiter to `/invite` matching the pattern already used by `/token`.

Closes #413

**- Test plan**
Added `TestInviteRateLimit` which sends 10 requests (exhausting the burst)
and asserts the 11th returns `429 Too Many Requests`. All existing invite
tests continue to pass.

make test 2>&1 | grep -E "TestInvite"
--- PASS: TestInvite/TestInvite (0.13s)
--- PASS: TestInvite/TestInviteExternalGitlab (0.14s)
--- PASS: TestInvite/TestInviteExternalGitlab_MismatchedEmails (0.13s)
--- PASS: TestInvite/TestInviteRateLimit (0.67s)
--- PASS: TestInvite/TestInvite_WithoutAccess (0.07s)
--- PASS: TestInvite/TestVerifyInvite (0.17s)
--- PASS: TestInvite/TestVerifyInvite_NoPassword (0.12s)

**- Description for the changelog**
Add tollbooth rate limiting to the /invite endpoint (10 req/min, burst of 10)

**- A picture of a cute animal (not mandatory but encouraged)**
🐾