### PR TITLE
fix: add stricter rules for the admin email field

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ If the mail server requires authentication, the password to use.
 
 Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email. The value is the number of seconds. Defaults to 900 (15 minutes).
 
+`SMTP_RESERVED_DOMAINS` - `string`
+
+A comma-separated list of domains that cannot be used as the `admin_email` sender address (e.g. `example.com,example.app`). Use this to prevent spoofing of domains your service owns. If not set, no domain restrictions are enforced.
+
 `MAILER_AUTOCONFIRM` - `bool`
 
 If you do not require email confirmation, you may set this to `true`. Defaults to `false`.

--- a/api/instance.go
+++ b/api/instance.go
@@ -70,6 +70,12 @@ func (a *API) CreateInstance(w http.ResponseWriter, r *http.Request) error {
 		return errors.Wrap(err, "Error generating id")
 	}
 
+	if params.BaseConfig != nil {
+		if err := params.BaseConfig.SMTP.Validate(); err != nil {
+			return badRequestError("Invalid SMTP configuration: %v", err)
+		}
+	}
+
 	i := models.Instance{
 		ID:         id,
 		UUID:       params.UUID,

--- a/api/instance.go
+++ b/api/instance.go
@@ -108,6 +108,12 @@ func (a *API) UpdateInstance(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Error decoding params: %v", err)
 	}
 
+	if params.BaseConfig != nil {
+		if err := params.BaseConfig.SMTP.Validate(); err != nil {
+			return badRequestError("Invalid SMTP configuration: %v", err)
+		}
+	}
+
 	if err := i.UpdateConfig(a.db, params.BaseConfig); err != nil {
 		return internalServerError("Database error updating instance").WithInternalError(err)
 	}

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -294,9 +294,9 @@ func (s *SMTPConfiguration) Validate() error {
 		if err != nil {
 			return errors.New("invalid admin_email address")
 		}
-		parts := strings.Split(addr.Address, "@")
-		if len(parts) == 2 {
-			domain := strings.ToLower(parts[1])
+		idx := strings.LastIndex(addr.Address, "@")
+		if idx >= 0 {
+			domain := strings.ToLower(addr.Address[idx+1:])
 			for _, reserved := range reservedDomains {
 				if domain == reserved || strings.HasSuffix(domain, "."+reserved) {
 					return errors.New("admin_email cannot use a Netlify-owned domain")

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -4,7 +4,9 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
+	"net/mail"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/joho/godotenv"
@@ -280,6 +282,27 @@ func (o *OAuthProviderConfiguration) Validate() error {
 	}
 	if o.RedirectURI == "" {
 		return errors.New("Missing redirect URI")
+	}
+	return nil
+}
+
+var reservedDomains = []string{"netlify.com", "netlify.app"}
+
+func (s *SMTPConfiguration) Validate() error {
+	if s.AdminEmail != "" {
+		addr, err := mail.ParseAddress(s.AdminEmail)
+		if err != nil {
+			return errors.New("invalid admin_email address")
+		}
+		parts := strings.Split(addr.Address, "@")
+		if len(parts) == 2 {
+			domain := strings.ToLower(parts[1])
+			for _, reserved := range reservedDomains {
+				if domain == reserved || strings.HasSuffix(domain, "."+reserved) {
+					return errors.New("admin_email cannot use a Netlify-owned domain")
+				}
+			}
+		}
 	}
 	return nil
 }

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -92,12 +92,13 @@ type ProviderConfiguration struct {
 }
 
 type SMTPConfiguration struct {
-	MaxFrequency time.Duration `json:"max_frequency" split_words:"true"`
-	Host         string        `json:"host"`
-	Port         int           `json:"port,omitempty" default:"587"`
-	User         string        `json:"user"`
-	Pass         string        `json:"pass,omitempty"`
-	AdminEmail   string        `json:"admin_email" split_words:"true"`
+	MaxFrequency    time.Duration `json:"max_frequency" split_words:"true"`
+	Host            string        `json:"host"`
+	Port            int           `json:"port,omitempty" default:"587"`
+	User            string        `json:"user"`
+	Pass            string        `json:"pass,omitempty"`
+	AdminEmail      string        `json:"admin_email" split_words:"true"`
+	ReservedDomains []string      `json:"reserved_domains" split_words:"true"`
 }
 
 type MailerConfiguration struct {
@@ -286,8 +287,6 @@ func (o *OAuthProviderConfiguration) Validate() error {
 	return nil
 }
 
-var reservedDomains = []string{"netlify.com", "netlify.app"}
-
 func (s *SMTPConfiguration) Validate() error {
 	if s.AdminEmail != "" {
 		addr, err := mail.ParseAddress(s.AdminEmail)
@@ -297,9 +296,10 @@ func (s *SMTPConfiguration) Validate() error {
 		idx := strings.LastIndex(addr.Address, "@")
 		if idx >= 0 {
 			domain := strings.ToLower(addr.Address[idx+1:])
-			for _, reserved := range reservedDomains {
-				if domain == reserved || strings.HasSuffix(domain, "."+reserved) {
-					return errors.New("admin_email cannot use a Netlify-owned domain")
+			for _, reserved := range s.ReservedDomains {
+				normalizedReserved := strings.ToLower(strings.TrimRight(strings.TrimSpace(reserved), "."))
+				if domain == normalizedReserved || strings.HasSuffix(domain, "."+normalizedReserved) {
+					return errors.New("admin_email cannot use a reserved domain")
 				}
 			}
 		}

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -30,12 +30,13 @@ func TestSMTPConfigurationValidate(t *testing.T) {
 		adminEmail string
 		wantErr    bool
 	}{
-		{"", false},                     // empty is fine
-		{"noreply@example.com", false},  // valid non-Netlify domain
-		{"team@netlify.com", true},      // reserved domain
-		{"user@netlify.app", true},      // reserved domain
-		{"user@sub.netlify.com", true},  // subdomain of reserved
-		{"not-an-email", true},          // invalid format
+		{"", false},                    // empty is fine
+		{"noreply@example.com", false}, // valid non-Netlify domain
+		{"team@netlify.com", true},     // reserved domain
+		{"user@netlify.app", true},     // reserved domain
+		{"user@sub.netlify.com", true}, // subdomain of reserved
+		{"not-an-email", true},         // invalid format
+		{"\"a@b\"@netlify.com", true},  // quoted local-part containing @
 	}
 
 	for _, tc := range cases {

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -25,6 +25,30 @@ func TestGlobal(t *testing.T) {
 	assert.Equal(t, "X-Request-ID", gc.API.RequestIDHeader)
 }
 
+func TestSMTPConfigurationValidate(t *testing.T) {
+	cases := []struct {
+		adminEmail string
+		wantErr    bool
+	}{
+		{"", false},                     // empty is fine
+		{"noreply@example.com", false},  // valid non-Netlify domain
+		{"team@netlify.com", true},      // reserved domain
+		{"user@netlify.app", true},      // reserved domain
+		{"user@sub.netlify.com", true},  // subdomain of reserved
+		{"not-an-email", true},          // invalid format
+	}
+
+	for _, tc := range cases {
+		s := &SMTPConfiguration{AdminEmail: tc.adminEmail}
+		err := s.Validate()
+		if tc.wantErr {
+			assert.Error(t, err, "expected error for admin_email %q", tc.adminEmail)
+		} else {
+			assert.NoError(t, err, "expected no error for admin_email %q", tc.adminEmail)
+		}
+	}
+}
+
 func TestTracing(t *testing.T) {
 	os.Setenv("GOTRUE_DB_DRIVER", "mysql")
 	os.Setenv("GOTRUE_DB_DATABASE_URL", "fake")

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -31,16 +31,19 @@ func TestSMTPConfigurationValidate(t *testing.T) {
 		wantErr    bool
 	}{
 		{"", false},                    // empty is fine
-		{"noreply@example.com", false}, // valid non-Netlify domain
-		{"team@netlify.com", true},     // reserved domain
-		{"user@netlify.app", true},     // reserved domain
-		{"user@sub.netlify.com", true}, // subdomain of reserved
+		{"noreply@foobar.com", false},  // valid non-reserved domain
+		{"team@example.com", true},     // reserved domain
+		{"user@example.app", true},     // reserved domain
+		{"user@sub.example.com", true}, // subdomain of reserved
 		{"not-an-email", true},         // invalid format
-		{"\"a@b\"@netlify.com", true},  // quoted local-part containing @
+		{"\"a@b\"@example.com", true},  // quoted local-part containing @
+		{"user@example.com", true},     // matches unnormalized reserved entry " Example.COM."
 	}
 
+	reservedDomains := []string{"example.com", "example.app", " Example.COM."} // last entry tests normalization
+
 	for _, tc := range cases {
-		s := &SMTPConfiguration{AdminEmail: tc.adminEmail}
+		s := &SMTPConfiguration{AdminEmail: tc.adminEmail, ReservedDomains: reservedDomains}
 		err := s.Validate()
 		if tc.wantErr {
 			assert.Error(t, err, "expected error for admin_email %q", tc.adminEmail)


### PR DESCRIPTION
**- Summary**

Adds validation to `SMTPConfiguration` that rejects `admin_email` values that the gotrue entity does not allow. Closing a vulnerability where an attacker could send SPF/DKIM/DMARC-authenticated phishing emails from `team@example.com` via the default mail infrastructure. Validation runs at update time in `UpdateInstance` and covers exact domain matches, subdomains, and invalid email formats.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
