### PR TITLE
fix: set explicit SameSite=Lax on auth cookies

### DIFF
--- a/api/token.go
+++ b/api/token.go
@@ -240,6 +240,7 @@ func (a *API) setCookieToken(config *conf.Configuration, tokenString string, ses
 		Secure:   true,
 		HttpOnly: true,
 		Path:     "/",
+		SameSite: http.SameSiteLaxMode,
 	}
 	if !session {
 		cookie.Expires = time.Now().Add(exp)
@@ -260,5 +261,6 @@ func (a *API) clearCookieToken(ctx context.Context, w http.ResponseWriter) {
 		Secure:   true,
 		HttpOnly: true,
 		Path:     "/",
+		SameSite: http.SameSiteLaxMode,
 	})
 }

--- a/api/token_cookie_test.go
+++ b/api/token_cookie_test.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netlify/gotrue/conf"
+)
+
+func TestSetCookieTokenSameSite(t *testing.T) {
+	config := &conf.Configuration{}
+	config.Cookie.Key = "nf_jwt"
+	config.Cookie.Duration = 3600
+
+	for _, session := range []bool{true, false} {
+		w := httptest.NewRecorder()
+		api := &API{}
+		require.NoError(t, api.setCookieToken(config, "the-token", session, w))
+
+		cookies := w.Result().Cookies()
+		require.Len(t, cookies, 1)
+		assert.Equal(t, http.SameSiteLaxMode, cookies[0].SameSite, "session=%v", session)
+		assert.True(t, cookies[0].HttpOnly)
+		assert.True(t, cookies[0].Secure)
+	}
+}
+
+func TestClearCookieTokenSameSite(t *testing.T) {
+	config := &conf.Configuration{}
+	config.Cookie.Key = "nf_jwt"
+	ctx := withConfig(context.Background(), config)
+
+	w := httptest.NewRecorder()
+	api := &API{}
+	api.clearCookieToken(ctx, w)
+
+	cookies := w.Result().Cookies()
+	require.Len(t, cookies, 1)
+	assert.Equal(t, http.SameSiteLaxMode, cookies[0].SameSite)
+	assert.True(t, cookies[0].HttpOnly)
+	assert.True(t, cookies[0].Secure)
+}


### PR DESCRIPTION
**- Summary**

The JWT cookies set by `/token` and cleared on logout had no SameSite attribute, so we were leaning on the browser default of Lax. Setting it explicitly to Lax in code keeps behaviour stable across browsers and matches how we already pin Secure and HttpOnly. Nothing changes for users.

**- Test plan**

- `go build ./...` and `go vet ./...` pass.
- Added `TestSetCookieTokenSameSite` and `TestClearCookieTokenSameSite` that exercise the cookie helpers directly and assert the cookie carries `SameSite=Lax`. Both pass locally.
- Full integration suite runs in CI.

**- Description for the changelog**

Set explicit `SameSite=Lax` on auth cookies.