### PR TITLE
fix: cap admin per_page at 500

### DIFF
--- a/api/pagination.go
+++ b/api/pagination.go
@@ -9,7 +9,10 @@ import (
 	"github.com/netlify/gotrue/models"
 )
 
-const defaultPerPage = 50
+const (
+	defaultPerPage = 50
+	maxPerPage     = 500
+)
 
 func calculateTotalPages(perPage, total uint64) uint64 {
 	pages := total / perPage
@@ -59,6 +62,9 @@ func paginate(r *http.Request) (*models.Pagination, error) {
 		perPage, err = strconv.ParseUint(queryPerPage, 10, 64)
 		if err != nil {
 			return nil, err
+		}
+		if perPage > maxPerPage {
+			return nil, badRequestError("per_page must not exceed %d", maxPerPage)
 		}
 	}
 

--- a/api/pagination_test.go
+++ b/api/pagination_test.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPaginate(t *testing.T) {
+	tests := []struct {
+		name        string
+		query       string
+		wantPage    uint64
+		wantPerPage uint64
+		wantErr     bool
+	}{
+		{"defaults", "", 1, defaultPerPage, false},
+		{"explicit page", "page=3", 3, defaultPerPage, false},
+		{"explicit per_page", "per_page=10", 1, 10, false},
+		{"per_page at max", fmt.Sprintf("per_page=%d", maxPerPage), 1, maxPerPage, false},
+		{"per_page above max", fmt.Sprintf("per_page=%d", maxPerPage+1), 0, 0, true},
+		{"per_page huge", "per_page=999999999", 0, 0, true},
+		{"page not a number", "page=abc", 0, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/admin/users?"+tt.query, nil)
+			p, err := paginate(req)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPage, p.Page)
+			assert.Equal(t, tt.wantPerPage, p.PerPage)
+		})
+	}
+}


### PR DESCRIPTION
**- Summary**

`per_page` on `/admin/users` wasn't bounded, so a caller could ask for `999999999` records and pull the whole user table in one query. This caps it at 500 and returns a 400 if you go over, so misbehaving clients fail loudly instead of silently getting partial pages.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Cap `/admin/users` `per_page` query parameter at 500.

**- A picture of a cute animal (not mandatory but encouraged)**