### PR TITLE
fix: set HTTP server read/write/idle timeouts

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -40,8 +40,12 @@ type API struct {
 func (a *API) ListenAndServe(hostAndPort string) {
 	log := logrus.WithField("component", "api")
 	server := &http.Server{
-		Addr:    hostAndPort,
-		Handler: a.handler,
+		Addr:              hostAndPort,
+		Handler:           a.handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	done := make(chan struct{})


### PR DESCRIPTION
**- Summary**

`http.Server` was constructed with no timeouts, which means Go uses its zero values (no timeout) and a slow client can hold a connection open indefinitely. This sets `ReadHeaderTimeout`, `ReadTimeout`, `WriteTimeout`, and `IdleTimeout` to standard values (10s, 30s, 60s, 120s) so we drop slowloris-style attacks before they tie up workers.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Add read, write, and idle timeouts to the HTTP server.

**- A picture of a cute animal (not mandatory but encouraged)**