### PR TITLE
fix: rate limit signup, recover, and verify endpoints

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -129,15 +129,30 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 
 		r.With(api.requireAdminCredentials).Post("/invite", api.Invite)
 
-		r.With(api.requireEmailProvider).Post("/signup", api.Signup)
-		r.With(api.requireEmailProvider).Post("/recover", api.Recover)
 		r.With(api.requireEmailProvider).With(api.limitHandler(
-			// Allow requests at a rate of 30 per 5 minutes.
+			// Allow up to 10 signup requests per minute per client.
+			tollbooth.NewLimiter(10.0/60, &limiter.ExpirableOptions{
+				DefaultExpirationTTL: time.Hour,
+			}).SetBurst(10),
+		)).Post("/signup", api.Signup)
+		r.With(api.requireEmailProvider).With(api.limitHandler(
+			// Allow up to 5 password recovery requests per minute per client.
+			tollbooth.NewLimiter(5.0/60, &limiter.ExpirableOptions{
+				DefaultExpirationTTL: time.Hour,
+			}).SetBurst(5),
+		)).Post("/recover", api.Recover)
+		r.With(api.requireEmailProvider).With(api.limitHandler(
+			// Allow up to 30 token requests per 5 minutes per client.
 			tollbooth.NewLimiter(30.0/(60*5), &limiter.ExpirableOptions{
 				DefaultExpirationTTL: time.Hour,
 			}).SetBurst(30),
 		)).Post("/token", api.Token)
-		r.Post("/verify", api.Verify)
+		r.With(api.limitHandler(
+			// Allow up to 30 verification attempts per minute per client.
+			tollbooth.NewLimiter(30.0/60, &limiter.ExpirableOptions{
+				DefaultExpirationTTL: time.Hour,
+			}).SetBurst(30),
+		)).Post("/verify", api.Verify)
 
 		r.With(api.requireAuthentication).Post("/logout", api.Logout)
 


### PR DESCRIPTION
**- Summary**

Only `/token` was rate-limited, leaving `/signup` open to email flooding, `/recover` open to account enumeration and mass recovery emails, and `/verify` open to confirmation-token brute force. This adds independent `tollbooth` limiters per endpoint: 10/min on `/signup`, 5/min on `/recover`, 30/min on `/verify`, each with its own bucket so a flood on one endpoint doesn't lock out the others.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Rate limit `/signup`, `/recover`, and `/verify` per client.

**- A picture of a cute animal (not mandatory but encouraged)**